### PR TITLE
Feat/loose enum handling

### DIFF
--- a/src/Sinch/Conversation/Apps/App.cs
+++ b/src/Sinch/Conversation/Apps/App.cs
@@ -13,7 +13,7 @@ namespace Sinch.Conversation.Apps
         /// <summary>
         ///     Gets or Sets ConversationMetadataReportView
         /// </summary>
-        public ConversationMetadataReportView? ConversationMetadataReportView { get; set; }
+        public ConversationMetadataReportView ConversationMetadataReportView { get; set; }
 
         /// <summary>
         ///     The display name for the app.

--- a/src/Sinch/Conversation/Apps/ConversationMetadataReportView.cs
+++ b/src/Sinch/Conversation/Apps/ConversationMetadataReportView.cs
@@ -1,16 +1,22 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Apps
 {
-    [JsonConverter(typeof(SinchEnumConverter<ConversationMetadataReportView>))]
-    public enum ConversationMetadataReportView
+    /// <summary>
+    ///     Represents the conversation metadata report view options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<ConversationMetadataReportView>))]
+    public record ConversationMetadataReportView(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "NONE")]
-        None,
+        /// <summary>
+        ///     No metadata report view.
+        /// </summary>
+        public static readonly ConversationMetadataReportView None = new("NONE");
 
-        [EnumMember(Value = "FULL")]
-        Full
+        /// <summary>
+        ///     Full metadata report view.
+        /// </summary>
+        public static readonly ConversationMetadataReportView Full = new("FULL");
     }
 }

--- a/src/Sinch/Conversation/Apps/Create/Request.cs
+++ b/src/Sinch/Conversation/Apps/Create/Request.cs
@@ -48,7 +48,7 @@ namespace Sinch.Conversation.Apps.Create
         /// <summary>
         ///     Whether or not Conversation API should store contacts and conversations for the app. For more information, see [Processing Modes](../../../../../conversation/processing-modes/).
         /// </summary>
-        public ProcessingMode? ProcessingMode { get; set; }
+        public ProcessingMode ProcessingMode { get; set; }
 
 
         /// <summary>

--- a/src/Sinch/Conversation/Apps/Create/Request.cs
+++ b/src/Sinch/Conversation/Apps/Create/Request.cs
@@ -11,7 +11,7 @@ namespace Sinch.Conversation.Apps.Create
         /// <summary>
         /// Gets or Sets ConversationMetadataReportView
         /// </summary>
-        public ConversationMetadataReportView? ConversationMetadataReportView { get; set; }
+        public ConversationMetadataReportView ConversationMetadataReportView { get; set; }
 
         /// <summary>
         ///     An array of channel credentials. The order of the credentials defines the app channel priority.

--- a/src/Sinch/Conversation/Apps/DispatchRetentionPolicy.cs
+++ b/src/Sinch/Conversation/Apps/DispatchRetentionPolicy.cs
@@ -14,7 +14,7 @@ namespace Sinch.Conversation.Apps
         /// <summary>
         /// Gets or Sets RetentionType
         /// </summary>
-        public DispatchRetentionPolicyType? RetentionType { get; set; }
+        public DispatchRetentionPolicyType RetentionType { get; set; }
 
         /// <summary>
         ///     Optional. The days before a message is eligible for deletion.

--- a/src/Sinch/Conversation/Apps/DispatchRetentionPolicyType.cs
+++ b/src/Sinch/Conversation/Apps/DispatchRetentionPolicyType.cs
@@ -1,17 +1,18 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Apps
 {
-    [JsonConverter(typeof(SinchEnumConverter<DispatchRetentionPolicyType>))]
-    public enum DispatchRetentionPolicyType
+    /// <summary>
+    ///     Represents the dispatch retention policy type options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<DispatchRetentionPolicyType>))]
+    public record DispatchRetentionPolicyType(string Value) : EnumRecord(Value)
     {
         /// <summary>
         ///     The default retention policy where messages older
-        ///     than ttl_days are automatically deleted from Conversation API database.
+        ///     than ttl_days are automatically deleted from the Conversation API database.
         /// </summary>
-        [EnumMember(Value = "MESSAGE_EXPIRE_POLICY")]
-        MessageExpirePolicy,
+        public static readonly DispatchRetentionPolicyType MessageExpirePolicy = new("MESSAGE_EXPIRE_POLICY");
     }
 }

--- a/src/Sinch/Conversation/Apps/ProcessingMode.cs
+++ b/src/Sinch/Conversation/Apps/ProcessingMode.cs
@@ -1,35 +1,26 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Apps
 {
     /// <summary>
-    ///     Whether or not Conversation API should store contacts and conversations for the app.
-    ///     For more information,
-    ///     see <see href="https://developers.sinch.com/docs/conversation/processing-modes/">Processing Modes</see>.
+    ///     Represents the processing mode options for Conversation API.
     /// </summary>
-    [JsonConverter(typeof(SinchEnumConverter<ProcessingMode>))]
-    public enum ProcessingMode 
+    [JsonConverter(typeof(EnumRecordJsonConverter<ProcessingMode>))]
+    public record ProcessingMode(string Value) : EnumRecord(Value)
     {
         /// <summary>
         ///     The default Processing Mode. Creates contacts and conversations automatically
         ///     when a message is sent or received and there's no existing contact or active conversation.
         /// </summary>
-        [EnumMember(Value = "CONVERSATION")]
-        Conversation,
+        public static readonly ProcessingMode Conversation = new("CONVERSATION");
+
         /// <summary>
         ///     Does not associate messages with contacts and conversations.
         ///     This processing mode is mostly intended for unidirectional high volume SMS use cases.
         ///     The lack of contacts and conversations limits some API features as related data won't be
-        ///     queryable in the
-        ///     <see href="https://developers.sinch.com/docs/conversation/api-reference/conversation/tag/Contact">
-        ///     Contact
-        ///     </see> and
-        ///     <see href="https://developers.sinch.com/docs/conversation/api-reference/conversation/tag/Conversation">
-        ///     Conversation</see> APIs.
+        ///     queryable in the Contact and Conversation APIs.
         /// </summary>
-        [EnumMember(Value = "DISPATCH")]
-        Dispatch
+        public static readonly ProcessingMode Dispatch = new("DISPATCH");
     }
 }

--- a/src/Sinch/Conversation/Apps/RetentionType.cs
+++ b/src/Sinch/Conversation/Apps/RetentionType.cs
@@ -1,33 +1,32 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Apps
 {
-    [JsonConverter(typeof(SinchEnumConverter<RetentionType>))]
-    public enum RetentionType
+    /// <summary>
+    ///     Represents the retention type options for Conversation API.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<RetentionType>))]
+    public record RetentionType(string Value) : EnumRecord(Value)
     {
         /// <summary>
-        ///     The default retention policy where messages older
-        ///     than ttl_days are automatically deleted from Conversation API database.
+        ///     The default retention policy where messages older than ttl_days are automatically deleted from Conversation API
+        ///     database.
         /// </summary>
-        [EnumMember(Value = "MESSAGE_EXPIRE_POLICY")]
-        MessageExpirePolicy,
+        public static readonly RetentionType MessageExpirePolicy = new("MESSAGE_EXPIRE_POLICY");
 
         /// <summary>
         ///     The conversation expire policy only considers the last message in a conversation.
-        ///     If the last message is older that ttl_days the entire conversation is deleted.
-        ///     The difference with MESSAGE_EXPIRE_POLICY is that messages with accept_time older than
-        ///     ttl_days are persisted as long as there is a newer message in the same conversation.
+        ///     If the last message is older than ttl_days, the entire conversation is deleted.
+        ///     The difference with MESSAGE_EXPIRE_POLICY is that messages with accept_time older than ttl_days are persisted
+        ///     as long as there is a newer message in the same conversation.
         /// </summary>
-        [EnumMember(Value = "CONVERSATION_EXPIRE_POLICY")]
-        ConversationExpirePolicy,
+        public static readonly RetentionType ConversationExpirePolicy = new("CONVERSATION_EXPIRE_POLICY");
 
         /// <summary>
         ///     Persist policy does not delete old messages or conversations.
         ///     Please note that message storage might be subject to additional charges in the future.
         /// </summary>
-        [EnumMember(Value = "PERSIST_RETENTION_POLICY")]
-        PersistRetentionPolicy,
+        public static readonly RetentionType PersistRetentionPolicy = new("PERSIST_RETENTION_POLICY");
     }
 }

--- a/src/Sinch/Conversation/Apps/Update/Request.cs
+++ b/src/Sinch/Conversation/Apps/Update/Request.cs
@@ -57,7 +57,7 @@ namespace Sinch.Conversation.Apps.Update
         /// <summary>
         ///     Whether or not Conversation API should store contacts and conversations for the app. For more information, see [Processing Modes](../../../../../conversation/processing-modes/).
         /// </summary>
-        public ProcessingMode? ProcessingMode { get; set; }
+        public ProcessingMode ProcessingMode { get; set; }
 
 
         /// <summary>

--- a/src/Sinch/Conversation/Apps/Update/Request.cs
+++ b/src/Sinch/Conversation/Apps/Update/Request.cs
@@ -24,7 +24,7 @@ namespace Sinch.Conversation.Apps.Update
         /// <summary>
         /// Gets or Sets ConversationMetadataReportView
         /// </summary>
-        public ConversationMetadataReportView? ConversationMetadataReportView { get; set; }
+        public ConversationMetadataReportView ConversationMetadataReportView { get; set; }
 
         /// <summary>
         ///     An array of channel credentials. The order of the credentials defines the app channel priority.

--- a/src/Sinch/Conversation/ConversationRegion.cs
+++ b/src/Sinch/Conversation/ConversationRegion.cs
@@ -1,8 +1,12 @@
 ﻿namespace Sinch.Conversation
 {
-    public enum ConversationRegion
+    /// <summary>
+    ///     Represents the Conversation region options.
+    /// </summary>
+    public record ConversationRegion(string Value)
     {
-        Us,
-        Eu,
+        public static readonly ConversationRegion Us = new("us");
+
+        public static readonly ConversationRegion Eu = new("eu");
     }
 }

--- a/src/Sinch/Conversation/MessageSource.cs
+++ b/src/Sinch/Conversation/MessageSource.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation
@@ -9,22 +8,20 @@ namespace Sinch.Conversation
     ///     Used for operations on messages in Dispatch Mode. For more information,
     ///     see <see href="https://developers.sinch.com/docs/conversation/processing-modes/">Processing Modes</see>.
     /// </summary>
-    [JsonConverter(typeof(SinchEnumConverter<MessageSource>))]
-    public enum MessageSource
+    [JsonConverter(typeof(EnumRecordJsonConverter<MessageSource>))]
+    public record MessageSource(string Value) : EnumRecord(Value)
     {
         /// <summary>
         ///     The default messages source. Retrieves messages sent in the default CONVERSATION processing mode,
         ///     which associates the messages with a specific conversation and contact.
         /// </summary>
-        [EnumMember(Value = "CONVERSATION_SOURCE")]
-        ConversationSource = 1,
+        public static readonly MessageSource ConversationSource = new("CONVERSATION_SOURCE");
 
         /// <summary>
         ///     Retrieves messages sent in the DISPATCH processing mode.
         ///     These types of messages are not associated with any conversation or contact.
         /// </summary>
-        [EnumMember(Value = "DISPATCH_SOURCE")]
-        DispatchSource = 2,
+        public static readonly MessageSource DispatchSource = new("DISPATCH_SOURCE");
     }
 }
 

--- a/src/Sinch/Conversation/Messages/ConversationChannel.cs
+++ b/src/Sinch/Conversation/Messages/ConversationChannel.cs
@@ -4,73 +4,73 @@ using Sinch.Core;
 namespace Sinch.Conversation.Messages
 {
     /// <summary>
-    /// Represents the identifier of the channel you want to include.
+    ///     Represents the identifier of the channel you want to include.
     /// </summary>
     [JsonConverter(typeof(EnumRecordJsonConverter<ConversationChannel>))]
     public record ConversationChannel(string Value) : EnumRecord(Value)
     {
         /// <summary>
-        /// WhatsApp channel.
+        ///     WhatsApp channel.
         /// </summary>
         public static readonly ConversationChannel WhatsApp = new("WHATSAPP");
 
         /// <summary>
-        /// RCS channel.
+        ///     RCS channel.
         /// </summary>
         public static readonly ConversationChannel Rcs = new("RCS");
 
         /// <summary>
-        /// SMS channel.
+        ///     SMS channel.
         /// </summary>
         public static readonly ConversationChannel Sms = new("SMS");
 
         /// <summary>
-        /// Messenger channel.
+        ///     Messenger channel.
         /// </summary>
         public static readonly ConversationChannel Messenger = new("MESSENGER");
 
         /// <summary>
-        /// Viber channel.
+        ///     Viber channel.
         /// </summary>
         public static readonly ConversationChannel Viber = new("VIBER");
 
         /// <summary>
-        /// ViberBm channel.
+        ///     ViberBm channel.
         /// </summary>
         public static readonly ConversationChannel ViberBm = new("VIBERBM");
 
         /// <summary>
-        /// MMS channel.
+        ///     MMS channel.
         /// </summary>
         public static readonly ConversationChannel Mms = new("MMS");
 
         /// <summary>
-        /// Instagram channel.
+        ///     Instagram channel.
         /// </summary>
         public static readonly ConversationChannel Instagram = new("INSTAGRAM");
 
         /// <summary>
-        /// Telegram channel.
+        ///     Telegram channel.
         /// </summary>
         public static readonly ConversationChannel Telegram = new("TELEGRAM");
 
         /// <summary>
-        /// KakaoTalk channel.
+        ///     KakaoTalk channel.
         /// </summary>
         public static readonly ConversationChannel KakaoTalk = new("KAKAOTALK");
 
         /// <summary>
-        /// KakaoTalkChat channel.
+        ///     KakaoTalkChat channel.
         /// </summary>
         public static readonly ConversationChannel KakaoTalkChat = new("KAKAOTALKCHAT");
 
         /// <summary>
-        /// Line channel.
+        ///     Line channel.
         /// </summary>
         public static readonly ConversationChannel Line = new("LINE");
 
         /// <summary>
-        /// WeChat channel.
+        ///     WeChat channel.
         /// </summary>
         public static readonly ConversationChannel WeChat = new("WECHAT");
     }

--- a/src/Sinch/Conversation/Messages/ConversationChannel.cs
+++ b/src/Sinch/Conversation/Messages/ConversationChannel.cs
@@ -1,92 +1,77 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Messages
 {
     /// <summary>
-    ///     The identifier of the channel you want to include. Must be one of the enum values.
+    /// Represents the identifier of the channel you want to include.
     /// </summary>
-    /// <value>The identifier of the channel you want to include. Must be one of the enum values.</value>
-    [JsonConverter(typeof(SinchEnumConverter<ConversationChannel>))]
-    public enum ConversationChannel
+    [JsonConverter(typeof(EnumRecordJsonConverter<ConversationChannel>))]
+    public record ConversationChannel(string Value) : EnumRecord(Value)
     {
         /// <summary>
-        ///     Enum WHATSAPP for value: WHATSAPP
+        /// WhatsApp channel.
         /// </summary>
-        [EnumMember(Value = "WHATSAPP")]
-        WhatsApp = 1,
+        public static readonly ConversationChannel WhatsApp = new("WHATSAPP");
 
         /// <summary>
-        ///     Enum RCS for value: RCS
+        /// RCS channel.
         /// </summary>
-        [EnumMember(Value = "RCS")]
-        Rcs = 2,
+        public static readonly ConversationChannel Rcs = new("RCS");
 
         /// <summary>
-        ///     Enum SMS for value: SMS
+        /// SMS channel.
         /// </summary>
-        [EnumMember(Value = "SMS")]
-        Sms = 3,
+        public static readonly ConversationChannel Sms = new("SMS");
 
         /// <summary>
-        ///     Enum MESSENGER for value: MESSENGER
+        /// Messenger channel.
         /// </summary>
-        [EnumMember(Value = "MESSENGER")]
-        Messenger = 4,
+        public static readonly ConversationChannel Messenger = new("MESSENGER");
 
         /// <summary>
-        ///     Enum VIBER for value: VIBER
+        /// Viber channel.
         /// </summary>
-        [EnumMember(Value = "VIBER")]
-        Viber = 5,
+        public static readonly ConversationChannel Viber = new("VIBER");
 
         /// <summary>
-        ///     Enum VIBERBM for value: VIBERBM
+        /// ViberBm channel.
         /// </summary>
-        [EnumMember(Value = "VIBERBM")]
-        ViberBm = 6,
+        public static readonly ConversationChannel ViberBm = new("VIBERBM");
 
         /// <summary>
-        ///     Enum MMS for value: MMS
+        /// MMS channel.
         /// </summary>
-        [EnumMember(Value = "MMS")]
-        Mms = 7,
+        public static readonly ConversationChannel Mms = new("MMS");
 
         /// <summary>
-        ///     Enum INSTAGRAM for value: INSTAGRAM
+        /// Instagram channel.
         /// </summary>
-        [EnumMember(Value = "INSTAGRAM")]
-        Instagram = 8,
+        public static readonly ConversationChannel Instagram = new("INSTAGRAM");
 
         /// <summary>
-        ///     Enum TELEGRAM for value: TELEGRAM
+        /// Telegram channel.
         /// </summary>
-        [EnumMember(Value = "TELEGRAM")]
-        Telegram = 9,
+        public static readonly ConversationChannel Telegram = new("TELEGRAM");
 
         /// <summary>
-        ///     Enum KAKAOTALK for value: KAKAOTALK
+        /// KakaoTalk channel.
         /// </summary>
-        [EnumMember(Value = "KAKAOTALK")]
-        KakaoTalk = 10,
+        public static readonly ConversationChannel KakaoTalk = new("KAKAOTALK");
 
         /// <summary>
-        ///     Enum KAKAOTALKCHAT for value: KAKAOTALKCHAT
+        /// KakaoTalkChat channel.
         /// </summary>
-        [EnumMember(Value = "KAKAOTALKCHAT")]
-        KakaoTalkChat = 11,
+        public static readonly ConversationChannel KakaoTalkChat = new("KAKAOTALKCHAT");
 
         /// <summary>
-        ///     Enum LINE for value: LINE
+        /// Line channel.
         /// </summary>
-        [EnumMember(Value = "LINE")]
-        Line = 12,
+        public static readonly ConversationChannel Line = new("LINE");
 
         /// <summary>
-        ///     Enum WECHAT for value: WECHAT
+        /// WeChat channel.
         /// </summary>
-        [EnumMember(Value = "WECHAT")]
-        WeChat = 13
+        public static readonly ConversationChannel WeChat = new("WECHAT");
     }
 }

--- a/src/Sinch/Conversation/Messages/List/Request.cs
+++ b/src/Sinch/Conversation/Messages/List/Request.cs
@@ -53,7 +53,7 @@ namespace Sinch.Conversation.Messages.List
         ///     Specifies the message source for which the request will be processed.
         ///     Used for operations on messages in Dispatch Mode. For more information, see Processing Modes.
         /// </summary>
-        public MessageSource? MessageSource { get; set; }
+        public MessageSource MessageSource { get; set; }
 
         /// <summary>
         ///     If true, fetch only recipient originated messages.

--- a/src/Sinch/Conversation/Messages/List/Request.cs
+++ b/src/Sinch/Conversation/Messages/List/Request.cs
@@ -1,5 +1,6 @@
 ﻿using System;
-using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+using Sinch.Core;
 
 namespace Sinch.Conversation.Messages.List
 {
@@ -47,7 +48,7 @@ namespace Sinch.Conversation.Messages.List
         /// </summary>
         public string PageToken { get; set; }
 
-        public View? View { get; set; }
+        public View View { get; set; }
 
         /// <summary>
         ///     Specifies the message source for which the request will be processed.
@@ -63,12 +64,20 @@ namespace Sinch.Conversation.Messages.List
     }
 
 
-    public enum View
+    /// <summary>
+    /// Represents the view options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<View>))]
+    public record View(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "WITH_METADATA")]
-        WithMetadata,
+        /// <summary>
+        /// View with metadata.
+        /// </summary>
+        public static readonly View WithMetadata = new("WITH_METADATA");
 
-        [EnumMember(Value = "WITHOUT_METADATA")]
-        WithoutMetadat
+        /// <summary>
+        /// View without metadata.
+        /// </summary>
+        public static readonly View WithoutMetadata = new("WITHOUT_METADATA");
     }
 }

--- a/src/Sinch/Conversation/Messages/Message/CardHeight.cs
+++ b/src/Sinch/Conversation/Messages/Message/CardHeight.cs
@@ -1,34 +1,32 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Messages.Message
 {
-    [JsonConverter(typeof(SinchEnumConverter<CardHeight>))]
-    public enum CardHeight
-    {   
+    /// <summary>
+    ///     Represents the card height options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<CardHeight>))]
+    public record CardHeight(string Value) : EnumRecord(Value)
+    {
         /// <summary>
-        ///     Enum UNSPECIFIEDHEIGHT for value: UNSPECIFIED_HEIGHT
+        ///     Unspecified height.
         /// </summary>
-        [EnumMember(Value = "UNSPECIFIED_HEIGHT")]
-        UnspecifiedHeight = 1,
+        public static readonly CardHeight UnspecifiedHeight = new("UNSPECIFIED_HEIGHT");
 
         /// <summary>
-        /// Enum SHORT for value: SHORT
+        ///     Short height.
         /// </summary>
-        [EnumMember(Value = "SHORT")]
-        Short = 2,
+        public static readonly CardHeight Short = new("SHORT");
 
         /// <summary>
-        /// Enum MEDIUM for value: MEDIUM
+        ///     Medium height.
         /// </summary>
-        [EnumMember(Value = "MEDIUM")]
-        Medium = 3,
+        public static readonly CardHeight Medium = new("MEDIUM");
 
         /// <summary>
-        /// Enum TALL for value: TALL
+        ///     Tall height.
         /// </summary>
-        [EnumMember(Value = "TALL")]
-        Tall = 4
+        public static readonly CardHeight Tall = new("TALL");
     }
 }

--- a/src/Sinch/Conversation/Messages/Message/CardMessage.cs
+++ b/src/Sinch/Conversation/Messages/Message/CardMessage.cs
@@ -12,7 +12,7 @@ namespace Sinch.Conversation.Messages.Message
         /// <summary>
         /// Gets or Sets Height
         /// </summary>
-        public CardHeight? Height { get; set; }
+        public CardHeight Height { get; set; }
 
         /// <summary>
         ///     You may include choices in your Card Message. The number of choices is limited to 10.

--- a/src/Sinch/Conversation/Messages/Message/ConversationDirection.cs
+++ b/src/Sinch/Conversation/Messages/Message/ConversationDirection.cs
@@ -1,31 +1,27 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Messages.Message
 {
     /// <summary>
-    /// Defines ConversationDirection
+    /// Represents the conversation direction options.
     /// </summary>
-    [JsonConverter(typeof(SinchEnumConverter<ConversationDirection>))]
-    public enum ConversationDirection
+    [JsonConverter(typeof(EnumRecordJsonConverter<ConversationDirection>))]
+    public record ConversationDirection(string Value) : EnumRecord(Value)
     {
         /// <summary>
-        /// Enum UNDEFINEDDIRECTION for value: UNDEFINED_DIRECTION
+        /// Undefined direction.
         /// </summary>
-        [EnumMember(Value = "UNDEFINED_DIRECTION")]
-        UndefinedDirection = 1,
+        public static readonly ConversationDirection UndefinedDirection = new("UNDEFINED_DIRECTION");
 
         /// <summary>
-        /// Enum TOAPP for value: TO_APP
+        /// To app direction.
         /// </summary>
-        [EnumMember(Value = "TO_APP")]
-        ToApp = 2,
+        public static readonly ConversationDirection ToApp = new("TO_APP");
 
         /// <summary>
-        /// Enum TOCONTACT for value: TO_CONTACT
+        /// To contact direction.
         /// </summary>
-        [EnumMember(Value = "TO_CONTACT")]
-        ToContact = 3
+        public static readonly ConversationDirection ToContact = new("TO_CONTACT");
     }
 }

--- a/src/Sinch/Conversation/Messages/Message/Message.cs
+++ b/src/Sinch/Conversation/Messages/Message/Message.cs
@@ -8,7 +8,7 @@ namespace Sinch.Conversation.Messages.Message
              /// <summary>
         /// Gets or Sets Direction
         /// </summary>
-        public ConversationDirection? Direction { get; set; }
+        public ConversationDirection Direction { get; set; }
 
         /// <summary>
         ///     The time Conversation API processed the message.

--- a/src/Sinch/Conversation/Messages/MessageQueue.cs
+++ b/src/Sinch/Conversation/Messages/MessageQueue.cs
@@ -1,19 +1,22 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation.Messages
 {
     /// <summary>
-    ///     Select the priority type for the message.
+    ///     Represents the message queue priority options.
     /// </summary>
-    [JsonConverter(typeof(SinchEnumConverter<MessageQueue>))]
-    public enum MessageQueue
+    [JsonConverter(typeof(EnumRecordJsonConverter<MessageQueue>))]
+    public record MessageQueue(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "NORMAL_PRIORITY")]
-        NormalPriority,
+        /// <summary>
+        ///     Selects normal priority for the message.
+        /// </summary>
+        public static readonly MessageQueue NormalPriority = new("NORMAL_PRIORITY");
 
-        [EnumMember(Value = "HIGH_PRIORITY")]
-        HighPriority,
+        /// <summary>
+        ///     Selects high priority for the message.
+        /// </summary>
+        public static readonly MessageQueue HighPriority = new("HIGH_PRIORITY");
     }
 }

--- a/src/Sinch/Conversation/Messages/Messages.cs
+++ b/src/Sinch/Conversation/Messages/Messages.cs
@@ -111,7 +111,7 @@ namespace Sinch.Conversation.Messages
         {
             var param = messagesSource is null
                 ? string.Empty
-                : $"?messages_source={messagesSource.Value.GetEnumString()}";
+                : $"?messages_source={messagesSource.Value}";
             return param;
         }
 

--- a/src/Sinch/Conversation/Messages/Messages.cs
+++ b/src/Sinch/Conversation/Messages/Messages.cs
@@ -40,7 +40,7 @@ namespace Sinch.Conversation.Messages
         /// <param name="messagesSource"><see cref="MessageSource"/></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<ConversationMessage> Get(string messageId, MessageSource? messagesSource = default,
+        Task<ConversationMessage> Get(string messageId, MessageSource messagesSource = default,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -68,7 +68,7 @@ namespace Sinch.Conversation.Messages
         /// <param name="messagesSource"><see cref="MessageSource"/></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task Delete(string messageId, MessageSource? messagesSource = default,
+        Task Delete(string messageId, MessageSource messagesSource = default,
             CancellationToken cancellationToken = default);
     }
 
@@ -97,7 +97,7 @@ namespace Sinch.Conversation.Messages
         }
 
         /// <inheritdoc/>  
-        public Task<ConversationMessage> Get(string messageId, MessageSource? messagesSource = default,
+        public Task<ConversationMessage> Get(string messageId, MessageSource messagesSource = default,
             CancellationToken cancellationToken = default)
         {
             var param = GetMessageSourceQueryParam(messagesSource);
@@ -107,7 +107,7 @@ namespace Sinch.Conversation.Messages
             return _http.Send<ConversationMessage>(uri, HttpMethod.Get, cancellationToken);
         }
 
-        private static string GetMessageSourceQueryParam(MessageSource? messagesSource)
+        private static string GetMessageSourceQueryParam(MessageSource messagesSource)
         {
             var param = messagesSource is null
                 ? string.Empty
@@ -125,7 +125,7 @@ namespace Sinch.Conversation.Messages
         }
 
         /// <inheritdoc/>  
-        public Task Delete(string messageId, MessageSource? messagesSource = default,
+        public Task Delete(string messageId, MessageSource messagesSource = default,
             CancellationToken cancellationToken = default)
         {
             var param = GetMessageSourceQueryParam(messagesSource);

--- a/src/Sinch/Conversation/Messages/Send/Request.cs
+++ b/src/Sinch/Conversation/Messages/Send/Request.cs
@@ -126,7 +126,7 @@ namespace Sinch.Conversation.Messages.Send
         /// <summary>
         ///     Overrides the app&#39;s [Processing Mode](../../../../../conversation/processing-modes/). Default value is &#x60;DEFAULT&#x60;.
         /// </summary>
-        public ProcessingStrategy? ProcessingStrategy { get; set; }
+        public ProcessingStrategy ProcessingStrategy { get; set; }
 
 
         /// <summary>

--- a/src/Sinch/Conversation/Messages/Send/Request.cs
+++ b/src/Sinch/Conversation/Messages/Send/Request.cs
@@ -22,7 +22,7 @@ namespace Sinch.Conversation.Messages.Send
         /// <summary>
         ///     Select the priority type for the message
         /// </summary>
-        public MessageQueue? Queue { get; set; }
+        public MessageQueue Queue { get; set; }
 
 
         /// <summary>

--- a/src/Sinch/Conversation/ProcessingStrategy.cs
+++ b/src/Sinch/Conversation/ProcessingStrategy.cs
@@ -1,16 +1,13 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Conversation
 {
-    [JsonConverter(typeof(SinchEnumConverter<ProcessingStrategy>))]
-    public enum ProcessingStrategy
+    
+    [JsonConverter(typeof(EnumRecordJsonConverter<ProcessingStrategy>))]
+    public record ProcessingStrategy(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "DEFAULT")]
-        Default,
-
-        [EnumMember(Value = "DISPATCH_ONLY")]
-        DispatchOnly
+        public static readonly ProcessingStrategy Default = new("DEFAULT");
+        public static readonly ProcessingStrategy DispatchOnly = new("DISPATCH_ONLY");
     }
 }

--- a/src/Sinch/Core/EnumRecord.cs
+++ b/src/Sinch/Core/EnumRecord.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sinch.Core
+{
+    public record EnumRecord(string Value);
+    
+    public class EnumRecordJsonConverter<T> : JsonConverter<T> where T : EnumRecord
+    {
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return Activator.CreateInstance(typeToConvert, reader.GetString()) as T;
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.Value);
+        }
+    }
+}

--- a/src/Sinch/Core/EnumRecord.cs
+++ b/src/Sinch/Core/EnumRecord.cs
@@ -4,7 +4,13 @@ using System.Text.Json.Serialization;
 
 namespace Sinch.Core
 {
-    public record EnumRecord(string Value);
+    public record EnumRecord(string Value)
+    {
+        public override string ToString()
+        {
+            return Value;
+        }
+    }
     
     public class EnumRecordJsonConverter<T> : JsonConverter<T> where T : EnumRecord
     {

--- a/src/Sinch/Core/Utils.cs
+++ b/src/Sinch/Core/Utils.cs
@@ -133,6 +133,11 @@ namespace Sinch.Core
                 return o.ToString()?.ToLowerInvariant();
             }
 
+            if (typeof(EnumRecord).IsAssignableFrom(type))
+            {
+                return type.GetProperty("Value", typeof(string))?.GetValue(o) as string;
+            }
+
             return o.ToString();
         }
     }

--- a/src/Sinch/Numbers/Active/List/Request.cs
+++ b/src/Sinch/Numbers/Active/List/Request.cs
@@ -50,7 +50,7 @@ namespace Sinch.Numbers.Active.List
         /// <summary>
         ///     Supported fields for ordering by phoneNumber or displayName.
         /// </summary>
-        public OrderBy? OrderBy { get; set; }
+        public OrderBy OrderBy { get; set; }
 
         internal string GetQueryString()
         {

--- a/src/Sinch/Numbers/Active/List/Request.cs
+++ b/src/Sinch/Numbers/Active/List/Request.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using Sinch.Core;
 
 namespace Sinch.Numbers.Active.List
 {
@@ -65,7 +64,7 @@ namespace Sinch.Numbers.Active.List
                 dict.Add(new KeyValuePair<string, string>("numberPattern.pattern", NumberPattern.Pattern));
                 if (NumberPattern.SearchPattern != null)
                     dict.Add(new KeyValuePair<string, string>("numberPattern.searchPattern",
-                        NumberPattern.SearchPattern.Value.ToUpperInvariant()));
+                        NumberPattern.SearchPattern.Value));
             }
 
             if (Capability is not null)

--- a/src/Sinch/Numbers/Active/List/Request.cs
+++ b/src/Sinch/Numbers/Active/List/Request.cs
@@ -78,8 +78,8 @@ namespace Sinch.Numbers.Active.List
 
             if (PageToken != null) dict.Add(new KeyValuePair<string, string>("pageToken", PageToken));
 
-            if (OrderBy.HasValue)
-                dict.Add(new KeyValuePair<string, string>("orderBy", OrderBy.Value.ToRequiredString()));
+            if (OrderBy is not null)
+                dict.Add(new KeyValuePair<string, string>("orderBy", OrderBy.Value));
 
             return string.Join("&", dict.Select(kvp => $"{kvp.Key}={WebUtility.UrlEncode(kvp.Value)}"));
         }

--- a/src/Sinch/Numbers/Active/List/Request.cs
+++ b/src/Sinch/Numbers/Active/List/Request.cs
@@ -57,7 +57,7 @@ namespace Sinch.Numbers.Active.List
             var dict = new List<KeyValuePair<string, string>>
             {
                 new("regionCode", RegionCode),
-                new("type", Utils.GetEnumString(Type))
+                new("type", Type.Value)
             };
 
             if (NumberPattern != null)
@@ -65,13 +65,13 @@ namespace Sinch.Numbers.Active.List
                 dict.Add(new KeyValuePair<string, string>("numberPattern.pattern", NumberPattern.Pattern));
                 if (NumberPattern.SearchPattern != null)
                     dict.Add(new KeyValuePair<string, string>("numberPattern.searchPattern",
-                        NumberPattern.SearchPattern.ToString()!.ToUpperInvariant()));
+                        NumberPattern.SearchPattern.Value.ToUpperInvariant()));
             }
 
             if (Capability is not null)
             {
                 dict.AddRange(Capability.Select(i =>
-                    new KeyValuePair<string, string>("capability", i.ToString().ToUpperInvariant())));
+                    new KeyValuePair<string, string>("capability", i.Value.ToUpperInvariant())));
             }
 
             if (PageSize is not null) dict.Add(new KeyValuePair<string, string>("pageSize", PageSize.Value.ToString()));

--- a/src/Sinch/Numbers/Active/OrderBy.cs
+++ b/src/Sinch/Numbers/Active/OrderBy.cs
@@ -1,27 +1,18 @@
-﻿using System.Runtime.Serialization;
-
-namespace Sinch.Numbers.Active
+﻿namespace Sinch.Numbers.Active
 {
-    public enum OrderBy
+    /// <summary>
+    ///     Represents the order by options for sorting.
+    /// </summary>
+    public record OrderBy(string Value)
     {
-        [EnumMember(Value = "phoneNumber")]
-        PhoneNumber,
-        [EnumMember(Value = "displayName")]
-        DisplayName
-    }
+        /// <summary>
+        ///     Sort by phone number.
+        /// </summary>
+        public static readonly OrderBy PhoneNumber = new("phoneNumber");
 
-    internal static class Extension
-    {
-        internal static string ToRequiredString(this OrderBy orderBy)
-        {
-            // unfortunately, non exhaustive pattern matching not working as expected and forces to cover _ case
-#pragma warning disable CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.
-            return orderBy switch
-            {
-                OrderBy.PhoneNumber => "phoneNumber",
-                OrderBy.DisplayName => "displayName"
-            };
-#pragma warning restore CS8524 // The switch expression does not handle some values of its input type (it is not exhaustive) involving an unnamed enum value.
-        }
+        /// <summary>
+        ///     Sort by display name.
+        /// </summary>
+        public static readonly OrderBy DisplayName = new("displayName");
     }
 }

--- a/src/Sinch/Numbers/Available/List/Request.cs
+++ b/src/Sinch/Numbers/Available/List/Request.cs
@@ -47,7 +47,7 @@ namespace Sinch.Numbers.Available.List
             var list = new List<KeyValuePair<string, string>>
             {
                 new("regionCode", RegionCode),
-                new("type", Utils.GetEnumString(Type))
+                new("type", Type.Value)
             };
 
             if (NumberPattern != null) list.AddRange(NumberPattern.GetQueryParamPairs());
@@ -55,7 +55,7 @@ namespace Sinch.Numbers.Available.List
             if (Capabilities is not null)
             {
                 list.AddRange(Capabilities.Select(i =>
-                    new KeyValuePair<string, string>("capabilities", i.ToString().ToUpperInvariant())));
+                    new KeyValuePair<string, string>("capabilities", i.Value.ToUpperInvariant())));
             }
 
             if (Size.HasValue) list.Add(new KeyValuePair<string, string>("size", Size.Value.ToString()));

--- a/src/Sinch/Numbers/Hooks/Event.cs
+++ b/src/Sinch/Numbers/Hooks/Event.cs
@@ -56,6 +56,6 @@ namespace Sinch.Numbers.Hooks
         ///     For numbers provisioning to SMS platform, there won't be any extra failureCode, as the result is binary.
         /// </summary>
         [JsonPropertyName("failureCode")]
-        public FailureCode? FailureCode { get; set; }
+        public FailureCode FailureCode { get; set; }
     }
 }

--- a/src/Sinch/Numbers/Hooks/EventStatus.cs
+++ b/src/Sinch/Numbers/Hooks/EventStatus.cs
@@ -1,15 +1,22 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Numbers.Hooks
 {
-    [JsonConverter(typeof(SinchEnumConverter<EventStatus>))]
-    public enum EventStatus
+    /// <summary>
+    ///     Represents the event status options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<EventStatus>))]
+    public record EventStatus(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "SUCCEEDED")]
-        Succeeded,
-        [EnumMember(Value = "FAILED")]
-        Failed
+        /// <summary>
+        ///     The event succeeded.
+        /// </summary>
+        public static readonly EventStatus Succeeded = new("SUCCEEDED");
+
+        /// <summary>
+        ///     The event failed.
+        /// </summary>
+        public static readonly EventStatus Failed = new("FAILED");
     }
 }

--- a/src/Sinch/Numbers/Hooks/EventType.cs
+++ b/src/Sinch/Numbers/Hooks/EventType.cs
@@ -1,15 +1,12 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Numbers.Hooks
 {
-    [JsonConverter(typeof(SinchEnumConverter<EventType>))]
-    public enum EventType
+    [JsonConverter(typeof(EnumRecordJsonConverter<EventType>))]
+    public record EventType(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "PROVISIONING_TO_SMS_PLATFORM")]
-        ProvisioningToSmsPlatform,
-        [EnumMember(Value = "LINK_TO_10DLC_CAMPAIGN")]
-        LinkTo10DlcCampaign
+        public static EventType ProvisioningToSmsPlatform = new("PROVISIONING_TO_SMS_PLATFORM");
+        public static EventType LinkTo10DlcCampaign = new("LINK_TO_10DLC_CAMPAIGN");
     }
 }

--- a/src/Sinch/Numbers/Hooks/FailureCode.cs
+++ b/src/Sinch/Numbers/Hooks/FailureCode.cs
@@ -1,55 +1,87 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Numbers.Hooks
 {
-    [JsonConverter(typeof(SinchEnumConverter<FailureCode>))]
-    public enum FailureCode
+    /// <summary>
+    ///     Represents the failure code options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<FailureCode>))]
+    public record FailureCode(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "CAMPAIGN_NOT_AVAILABLE")]
-        CampaignNotAvailable,
-    
-        [EnumMember(Value = "EXCEEDED_10DLC_LIMIT")]
-        Exceeded10DlcLimit,
-    
-        [EnumMember(Value = "NUMBER_PROVISIONING_FAILED")]
-        NumberProvisioningFailed,
-    
-        [EnumMember(Value = "PARTNER_SERVICE_UNAVAILABLE")]
-        PartnerServiceUnavailable,
-    
-        [EnumMember(Value = "CAMPAIGN_PENDING_ACCEPTANCE")]
-        CampaignPendingAcceptance,
-    
-        [EnumMember(Value = "MNO_SHARING_ERROR")]
-        MnoSharingError,
-    
-        [EnumMember(Value = "CAMPAIGN_PROVISIONING_FAILED")]
-        CampaignProvisioningFailed,
-    
-        [EnumMember(Value = "CAMPAIGN_EXPIRED")]
-        CampaignExpired,
-    
-        [EnumMember(Value = "CAMPAIGN_MNO_REJECTED")]
-        CampaignMnoRejected,
-    
-        [EnumMember(Value = "CAMPAIGN_MNO_SUSPENDED")]
-        CampaignMnoSuspended,
-    
-        [EnumMember(Value = "CAMPAIGN_MNO_REVIEW")]
-        CampaignMnoReview,
-    
-        [EnumMember(Value = "INSUFFICIENT_BALANCE")]
-        InsufficientBalance,
-    
-        [EnumMember(Value = "MOCK_CAMPAIGN_NOT_ALLOWED")]
-        MockCampaignNotAllowed,
-    
-        [EnumMember(Value = "TFN_NOT_ALLOWED")]
-        TfnNotAllowed,
-    
-        [EnumMember(Value = "INVALID_NNID")]
-        InvalidNnid
+        /// <summary>
+        ///     Campaign is not available.
+        /// </summary>
+        public static readonly FailureCode CampaignNotAvailable = new("CAMPAIGN_NOT_AVAILABLE");
+
+        /// <summary>
+        ///     Exceeded 10 DLC limit.
+        /// </summary>
+        public static readonly FailureCode Exceeded10DlcLimit = new("EXCEEDED_10DLC_LIMIT");
+
+        /// <summary>
+        ///     Number provisioning failed.
+        /// </summary>
+        public static readonly FailureCode NumberProvisioningFailed = new("NUMBER_PROVISIONING_FAILED");
+
+        /// <summary>
+        ///     Partner service is unavailable.
+        /// </summary>
+        public static readonly FailureCode PartnerServiceUnavailable = new("PARTNER_SERVICE_UNAVAILABLE");
+
+        /// <summary>
+        ///     Campaign is pending acceptance.
+        /// </summary>
+        public static readonly FailureCode CampaignPendingAcceptance = new("CAMPAIGN_PENDING_ACCEPTANCE");
+
+        /// <summary>
+        ///     MNO sharing error.
+        /// </summary>
+        public static readonly FailureCode MnoSharingError = new("MNO_SHARING_ERROR");
+
+        /// <summary>
+        ///     Campaign provisioning failed.
+        /// </summary>
+        public static readonly FailureCode CampaignProvisioningFailed = new("CAMPAIGN_PROVISIONING_FAILED");
+
+        /// <summary>
+        ///     Campaign expired.
+        /// </summary>
+        public static readonly FailureCode CampaignExpired = new("CAMPAIGN_EXPIRED");
+
+        /// <summary>
+        ///     Campaign MNO rejected.
+        /// </summary>
+        public static readonly FailureCode CampaignMnoRejected = new("CAMPAIGN_MNO_REJECTED");
+
+        /// <summary>
+        ///     Campaign MNO suspended.
+        /// </summary>
+        public static readonly FailureCode CampaignMnoSuspended = new("CAMPAIGN_MNO_SUSPENDED");
+
+        /// <summary>
+        ///     Campaign MNO review.
+        /// </summary>
+        public static readonly FailureCode CampaignMnoReview = new("CAMPAIGN_MNO_REVIEW");
+
+        /// <summary>
+        ///     Insufficient balance.
+        /// </summary>
+        public static readonly FailureCode InsufficientBalance = new("INSUFFICIENT_BALANCE");
+
+        /// <summary>
+        ///     Mock campaign is not allowed.
+        /// </summary>
+        public static readonly FailureCode MockCampaignNotAllowed = new("MOCK_CAMPAIGN_NOT_ALLOWED");
+
+        /// <summary>
+        ///     TFN (Toll-Free Number) is not allowed.
+        /// </summary>
+        public static readonly FailureCode TfnNotAllowed = new("TFN_NOT_ALLOWED");
+
+        /// <summary>
+        ///     Invalid NNID (Numbering Plan ID).
+        /// </summary>
+        public static readonly FailureCode InvalidNnid = new("INVALID_NNID");
     }
 }

--- a/src/Sinch/Numbers/Hooks/ResourceType.cs
+++ b/src/Sinch/Numbers/Hooks/ResourceType.cs
@@ -1,17 +1,27 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Numbers.Hooks
 {
-    [JsonConverter(typeof(SinchEnumConverter<ResourceType>))]
-    public enum ResourceType
+    /// <summary>
+    ///     Represents the resource type options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<ResourceType>))]
+    public record ResourceType(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "NUMBER")]
-        Number,
-        [EnumMember(Value = "HOSTING_ORDER")]
-        HostingOrder,
-        [EnumMember(Value = "Brand")]
-        Brand
+        /// <summary>
+        ///     Represents a number resource.
+        /// </summary>
+        public static readonly ResourceType Number = new("NUMBER");
+
+        /// <summary>
+        ///     Represents a hosting order resource.
+        /// </summary>
+        public static readonly ResourceType HostingOrder = new("HOSTING_ORDER");
+
+        /// <summary>
+        ///     Represents a brand resource.
+        /// </summary>
+        public static readonly ResourceType Brand = new("Brand");
     }
 }

--- a/src/Sinch/Numbers/NumberPattern.cs
+++ b/src/Sinch/Numbers/NumberPattern.cs
@@ -26,7 +26,7 @@ namespace Sinch.Numbers
             list.Add(new KeyValuePair<string, string>("numberPattern.pattern", Pattern));
             if (SearchPattern is not null)
                 list.Add(new KeyValuePair<string, string>("numberPattern.searchPattern",
-                    SearchPattern.Value.ToUpperInvariant()));
+                    SearchPattern.Value));
 
             return list;
         }
@@ -42,16 +42,16 @@ namespace Sinch.Numbers
         /// When using START, a plus sign (+) must be included and URL encoded, so %2B. 
         /// For example, to search for area code 206 in the US, you would enter, %2b1206.
         /// </summary>
-        public static readonly SearchPattern Start = new("Start");
+        public static readonly SearchPattern Start = new("START");
 
         /// <summary>
         /// The number pattern entered is contained somewhere in the number, the location being undefined.
         /// </summary>
-        public static readonly SearchPattern Contain = new("Contain");
+        public static readonly SearchPattern Contain = new("CONTAINS");
 
         /// <summary>
         /// The number ends with the number pattern entered.
         /// </summary>
-        public static readonly SearchPattern End = new("End");
+        public static readonly SearchPattern End = new("END");
     }
 }

--- a/src/Sinch/Numbers/NumberPattern.cs
+++ b/src/Sinch/Numbers/NumberPattern.cs
@@ -23,10 +23,16 @@ namespace Sinch.Numbers
         internal IEnumerable<KeyValuePair<string, string>> GetQueryParamPairs()
         {
             var list = new List<KeyValuePair<string, string>>();
-            list.Add(new KeyValuePair<string, string>("numberPattern.pattern", Pattern));
+            if (!string.IsNullOrEmpty(Pattern))
+            {
+                list.Add(new KeyValuePair<string, string>("numberPattern.pattern", Pattern));
+            }
+
             if (SearchPattern is not null)
+            {
                 list.Add(new KeyValuePair<string, string>("numberPattern.searchPattern",
                     SearchPattern.Value));
+            }
 
             return list;
         }

--- a/src/Sinch/Numbers/NumberPattern.cs
+++ b/src/Sinch/Numbers/NumberPattern.cs
@@ -18,37 +18,40 @@ namespace Sinch.Numbers
         /// <summary>
         ///     Search pattern to apply. The options are, START, CONTAIN, and END.
         /// </summary>
-        public SearchPattern? SearchPattern { get; set; }
+        public SearchPattern SearchPattern { get; set; }
 
         internal IEnumerable<KeyValuePair<string, string>> GetQueryParamPairs()
         {
             var list = new List<KeyValuePair<string, string>>();
             list.Add(new KeyValuePair<string, string>("numberPattern.pattern", Pattern));
-            if (SearchPattern.HasValue)
+            if (SearchPattern is not null)
                 list.Add(new KeyValuePair<string, string>("numberPattern.searchPattern",
-                    SearchPattern.Value.ToString()!.ToUpperInvariant()));
+                    SearchPattern.Value.ToUpperInvariant()));
 
             return list;
         }
     }
 
-    public enum SearchPattern
+    /// <summary>
+    /// Represents the search pattern options for phone numbers.
+    /// </summary>
+    public record SearchPattern(string Value)
     {
         /// <summary>
-        ///     Numbers that begin with the numberPattern.pattern entered. Often used to search for a specific area code. When
-        ///     using START, a plus sign (+) must be included and URL encoded, so %2B. For example, to search for area code 206 in
-        ///     the US, you would enter, %2b1206.
+        /// Numbers that begin with the number pattern entered. Often used to search for a specific area code. 
+        /// When using START, a plus sign (+) must be included and URL encoded, so %2B. 
+        /// For example, to search for area code 206 in the US, you would enter, %2b1206.
         /// </summary>
-        Start,
+        public static readonly SearchPattern Start = new("Start");
 
         /// <summary>
-        ///     The number pattern entered is contained somewhere in the number, the location being undefined.
+        /// The number pattern entered is contained somewhere in the number, the location being undefined.
         /// </summary>
-        Contain,
+        public static readonly SearchPattern Contain = new("Contain");
 
         /// <summary>
-        ///     The number ends with the number pattern entered.
+        /// The number ends with the number pattern entered.
         /// </summary>
-        End
+        public static readonly SearchPattern End = new("End");
     }
 }

--- a/src/Sinch/Numbers/Product.cs
+++ b/src/Sinch/Numbers/Product.cs
@@ -1,18 +1,22 @@
 ﻿using System.Text.Json.Serialization;
+using Sinch.Core;
 
 namespace Sinch.Numbers
 {
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public enum Product
+    /// <summary>
+    ///     Represents the product options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<Product>))]
+    public record Product(string Value) : EnumRecord(Value)
     {
         /// <summary>
         ///     The SMS product can use the number.
         /// </summary>
-        Sms,
+        public static readonly Product Sms = new("Sms");
 
         /// <summary>
         ///     The Voice product can use the number.
         /// </summary>
-        Voice
+        public static readonly Product Voice = new("Voice");
     }
 }

--- a/src/Sinch/Numbers/ProvisioningStatus.cs
+++ b/src/Sinch/Numbers/ProvisioningStatus.cs
@@ -1,19 +1,27 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Numbers
 {
-    [JsonConverter(typeof(SinchEnumConverter<ProvisioningStatus>))]
-    public enum ProvisioningStatus
+    /// <summary>
+    ///     Represents the provisioning status options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<ProvisioningStatus>))]
+    public record ProvisioningStatus(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "WAITING")]
-        Waiting,
+        /// <summary>
+        ///     The provisioning is waiting.
+        /// </summary>
+        public static readonly ProvisioningStatus Waiting = new("WAITING");
 
-        [EnumMember(Value = "IN_PROGRESS")]
-        InProgress,
+        /// <summary>
+        ///     The provisioning is in progress.
+        /// </summary>
+        public static readonly ProvisioningStatus InProgress = new("IN_PROGRESS");
 
-        [EnumMember(Value = "FAILED")]
-        Failed
+        /// <summary>
+        ///     The provisioning has failed.
+        /// </summary>
+        public static readonly ProvisioningStatus Failed = new("FAILED");
     }
 }

--- a/src/Sinch/Numbers/Regions.cs
+++ b/src/Sinch/Numbers/Regions.cs
@@ -48,7 +48,7 @@ namespace Sinch.Numbers
             var typesStr = string.Empty;
             if (types is not null)
             {
-                var typesQuery = string.Join("&", types.Select(x => "types=" + Utils.GetEnumString(x)));
+                var typesQuery = string.Join("&", types.Select(x => "types=" + x.Value));
                 if (!string.IsNullOrEmpty(typesQuery))
                 {
                     typesStr = typesQuery;

--- a/src/Sinch/Numbers/Types.cs
+++ b/src/Sinch/Numbers/Types.cs
@@ -1,28 +1,27 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.Numbers
 {
-    [JsonConverter(typeof(SinchEnumConverter<Types>))]
-    public enum Types
+    /// <summary>
+    ///     Represents the types of numbers.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<Types>))]
+    public record Types(string Value) : EnumRecord(Value)
     {
         /// <summary>
-        ///     Numbers that belong to a specific range.
+        ///     Numbers that belong to a specific range (e.g., mobile numbers).
         /// </summary>
-        [EnumMember(Value = "MOBILE")]
-        Mobile,
+        public static readonly Types Mobile = new("MOBILE");
 
         /// <summary>
-        ///     Numbers that are assigned to a specific geographic region
+        ///     Numbers that are assigned to a specific geographic region (e.g., local numbers).
         /// </summary>
-        [EnumMember(Value = "LOCAL")]
-        Local,
+        public static readonly Types Local = new("LOCAL");
 
         /// <summary>
-        ///     Number that are free of charge for the calling party but billed for all arriving calls.
+        ///     Numbers that are free of charge for the calling party but billed for all arriving calls (e.g., toll-free numbers).
         /// </summary>
-        [EnumMember(Value = "TOLL_FREE")]
-        TollFree
+        public static readonly Types TollFree = new("TOLL_FREE");
     }
 }

--- a/src/Sinch/SMS/Batches/Batch.cs
+++ b/src/Sinch/SMS/Batches/Batch.cs
@@ -45,7 +45,7 @@ namespace Sinch.SMS.Batches
         /// <summary>
         ///     Regular SMS
         /// </summary>
-        public SmsType Type { get; } = SmsType.MtText;
+        public SmsType Type { get; set; }
 
         /// <summary>
         ///     Timestamp for when batch was created.

--- a/src/Sinch/SMS/Batches/DryRun/Request.cs
+++ b/src/Sinch/SMS/Batches/DryRun/Request.cs
@@ -61,7 +61,7 @@ namespace Sinch.SMS.Batches.DryRun
         ///     Request delivery report callback. <br /><br />
         ///     Note that delivery reports can be fetched from the API regardless of this setting.
         /// </summary>
-        public DeliveryReport? DeliveryReport { get; set; }
+        public DeliveryReport DeliveryReport { get; set; }
 
         /// <summary>
         ///     If set in the future, the message will be delayed until send_at occurs. <br /><br />

--- a/src/Sinch/SMS/Batches/DryRun/Request.cs
+++ b/src/Sinch/SMS/Batches/DryRun/Request.cs
@@ -50,7 +50,7 @@ namespace Sinch.SMS.Batches.DryRun
         /// <summary>
         ///     Identifies the type of batch message.
         /// </summary>
-        public SmsType? Type { get; set; }
+        public SmsType Type { get; set; }
 
         /// <summary>
         ///     The UDH header of a binary message. Max 140 bytes together with body.<br /><br />Required if type is mt_binary.

--- a/src/Sinch/SMS/Batches/Update/Request.cs
+++ b/src/Sinch/SMS/Batches/Update/Request.cs
@@ -29,7 +29,7 @@ namespace Sinch.SMS.Batches.Update
         ///     Request delivery report callback. Note that delivery reports can be fetched from the API regardless of this
         ///     setting.
         /// </summary>
-        public DeliveryReport? DeliveryReport { get; set; }
+        public DeliveryReport DeliveryReport { get; set; }
 
         /// <summary>
         ///     If set, in the future the message will be delayed until send_at occurs.

--- a/src/Sinch/SMS/DeliveryReport.cs
+++ b/src/Sinch/SMS/DeliveryReport.cs
@@ -1,44 +1,41 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.SMS
 {
-    [JsonConverter(typeof(SinchEnumConverter<DeliveryReport>))]
-    public enum DeliveryReport
+    /// <summary>
+    /// Represents the delivery report options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<DeliveryReport>))]
+    public record DeliveryReport(string Value) : EnumRecord(Value)
     {
         /// <summary>
-        ///     No delivery report callback will be sent.
+        /// No delivery report callback will be sent.
         /// </summary>
-        [EnumMember(Value = "none")]
-        None,
+        public static readonly DeliveryReport None = new("none");
 
         /// <summary>
-        ///     A single delivery report callback will be sent.
+        /// A single delivery report callback will be sent.
         /// </summary>
-        [EnumMember(Value = "summary")]
-        Summary,
+        public static readonly DeliveryReport Summary = new("summary");
 
         /// <summary>
-        ///     A single delivery report callback will be sent which includes a list of recipients per delivery status.
+        /// A single delivery report callback will be sent which includes a list of recipients per delivery status.
         /// </summary>
-        [EnumMember(Value = "full")]
-        Full,
+        public static readonly DeliveryReport Full = new("full");
 
         /// <summary>
-        ///     A delivery report callback will be sent for each status change of a message.
-        ///     This could result in a lot of callbacks and should be used with caution for larger batches.
-        ///     These delivery reports also include a timestamp of when the Delivery Report originated from the SMSC.
+        /// A delivery report callback will be sent for each status change of a message.
+        /// This could result in a lot of callbacks and should be used with caution for larger batches.
+        /// These delivery reports also include a timestamp of when the Delivery Report originated from the SMSC.
         /// </summary>
-        [EnumMember(Value = "per_recipient")]
-        PerRecipient,
+        public static readonly DeliveryReport PerRecipient = new("per_recipient");
 
         /// <summary>
-        ///     A delivery report callback representing the final status of a message will be sent for each recipient.
-        ///     This will send only one callback per recipient, compared to the multiple callbacks sent when using per_recipient.
-        ///     The delivery report will also include a timestamp of when it originated from the SMSC.
+        /// A delivery report callback representing the final status of a message will be sent for each recipient.
+        /// This will send only one callback per recipient, compared to the multiple callbacks sent when using per_recipient.
+        /// The delivery report will also include a timestamp of when it originated from the SMSC.
         /// </summary>
-        [EnumMember(Value = "per_recipient_final")]
-        PerRecipientFinal
+        public static readonly DeliveryReport PerRecipientFinal = new("per_recipient_final");
     }
 }

--- a/src/Sinch/SMS/DeliveryReports/DeliveryReportStatus.cs
+++ b/src/Sinch/SMS/DeliveryReports/DeliveryReportStatus.cs
@@ -3,54 +3,57 @@ using Sinch.Core;
 
 namespace Sinch.SMS.DeliveryReports
 {
-    [JsonConverter(typeof(SinchEnumConverter<DeliveryReportStatus>))]
-    public enum DeliveryReportStatus
+    /// <summary>
+    ///     Represents the delivery report status options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<DeliveryReportStatus>))]
+    public record DeliveryReportStatus(string Value) : EnumRecord(Value)
     {
         /// <summary>
-        ///     Message is queued within REST API system and will be dispatched according to the rate of the account.
+        ///     Message is queued within the REST API system and will be dispatched according to the rate of the account.
         /// </summary>
-        Queued,
+        public static readonly DeliveryReportStatus Queued = new("Queued");
 
         /// <summary>
         ///     Message has been dispatched and accepted for delivery by the SMSC.
         /// </summary>
-        Dispatched,
+        public static readonly DeliveryReportStatus Dispatched = new("Dispatched");
 
         /// <summary>
         ///     Message was aborted before reaching the SMSC.
         /// </summary>
-        Aborted,
+        public static readonly DeliveryReportStatus Aborted = new("Aborted");
 
         /// <summary>
         ///     Message was rejected by the SMSC.
         /// </summary>
-        Rejected,
+        public static readonly DeliveryReportStatus Rejected = new("Rejected");
 
         /// <summary>
         ///     Message has been deleted. Message was deleted by a remote SMSC.
-        ///     This may happen if the destination is an invalid MSISDN or opted out subscriber.
+        ///     This may happen if the destination is an invalid MSISDN or opted-out subscriber.
         /// </summary>
-        Deleted,
+        public static readonly DeliveryReportStatus Deleted = new("Deleted");
 
         /// <summary>
         ///     Message has been delivered.
         /// </summary>
-        Delivered,
+        public static readonly DeliveryReportStatus Delivered = new("Delivered");
 
         /// <summary>
         ///     Message failed to be delivered.
         /// </summary>
-        Failed,
+        public static readonly DeliveryReportStatus Failed = new("Failed");
 
         /// <summary>
         ///     Message expired before delivery to the SMSC. This may happen if the expiry time for the message was very short.
         /// </summary>
-        Expired,
+        public static readonly DeliveryReportStatus Expired = new("Expired");
 
         /// <summary>
         ///     Message was delivered to the SMSC but no Delivery Receipt has been received or
         ///     a Delivery Receipt that couldn't be interpreted was received.
         /// </summary>
-        Unknown
+        public static readonly DeliveryReportStatus Unknown = new("Unknown");
     }
 }

--- a/src/Sinch/SMS/DeliveryReports/DeliveryReportType.cs
+++ b/src/Sinch/SMS/DeliveryReports/DeliveryReportType.cs
@@ -1,33 +1,51 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.SMS.DeliveryReports
 {
-    [JsonConverter(typeof(SinchEnumConverter<DeliveryReportType>))]
-    public enum DeliveryReportType
+    /// <summary>
+    ///     Represents the delivery report type options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<DeliveryReportType>))]
+    public record DeliveryReportType(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "delivery_report_sms")]
-        Sms,
+        /// <summary>
+        ///     Represents a delivery report for SMS.
+        /// </summary>
+        public static readonly DeliveryReportType Sms = new("delivery_report_sms");
 
-        [EnumMember(Value = "delivery_report_mms")]
-        Mms
+        /// <summary>
+        ///     Represents a delivery report for MMS.
+        /// </summary>
+        public static readonly DeliveryReportType Mms = new("delivery_report_mms");
     }
 
-    [JsonConverter(typeof(SinchEnumConverter<DeliveryReportVerbosityType>))]
-    public enum DeliveryReportVerbosityType
+    /// <summary>
+    ///     Represents the delivery report verbosity type options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<DeliveryReportVerbosityType>))]
+    public record DeliveryReportVerbosityType(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "summary")]
-        Summary,
+        /// <summary>
+        ///     Represents a summary delivery report.
+        /// </summary>
+        public static readonly DeliveryReportVerbosityType Summary = new("summary");
 
-        [EnumMember(Value = "full")]
-        Full
+        /// <summary>
+        ///     Represents a full delivery report.
+        /// </summary>
+        public static readonly DeliveryReportVerbosityType Full = new("full");
     }
-    
-    [JsonConverter(typeof(SinchEnumConverter<RecipientDeliveryReportType>))]
-    public enum RecipientDeliveryReportType
+
+    /// <summary>
+    ///     Represents the recipient delivery report type options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<RecipientDeliveryReportType>))]
+    public record RecipientDeliveryReportType(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "recipient_delivery_report_sms")]
-        Sms,
+        /// <summary>
+        ///     Represents a recipient delivery report for SMS.
+        /// </summary>
+        public static readonly RecipientDeliveryReportType Sms = new("recipient_delivery_report_sms");
     }
 }

--- a/src/Sinch/SMS/DeliveryReports/Get/Request.cs
+++ b/src/Sinch/SMS/DeliveryReports/Get/Request.cs
@@ -16,7 +16,7 @@ namespace Sinch.SMS.DeliveryReports.Get
         public string BatchId { get; set; }
 #endif
 
-        public DeliveryReportVerbosityType? DeliveryReportType { get; set; }
+        public DeliveryReportVerbosityType DeliveryReportType { get; set; }
 
         /// <summary>
         ///     A list of <see cref="DeliveryReportStatus" /> to include.

--- a/src/Sinch/SMS/DeliveryReports/Get/Request.cs
+++ b/src/Sinch/SMS/DeliveryReports/Get/Request.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Sinch.Core;
 
 namespace Sinch.SMS.DeliveryReports.Get
@@ -38,7 +39,7 @@ namespace Sinch.SMS.DeliveryReports.Get
 
             if (Statuses is not null && Statuses.Count > 0)
             {
-                kvp.Add(new KeyValuePair<string, string>("status", string.Join(",", Statuses)));
+                kvp.Add(new KeyValuePair<string, string>("status", string.Join(",", Statuses.Select(x => x.Value))));
             }
 
             if (Code is not null && Code.Count > 0)

--- a/src/Sinch/SMS/DeliveryReports/Get/Request.cs
+++ b/src/Sinch/SMS/DeliveryReports/Get/Request.cs
@@ -31,10 +31,10 @@ namespace Sinch.SMS.DeliveryReports.Get
         internal string GetQueryString()
         {
             var kvp = new List<KeyValuePair<string, string>>();
-            if (DeliveryReportType.HasValue)
+            if (DeliveryReportType is not null)
             {
                 kvp.Add(
-                    new KeyValuePair<string, string>("type", Utils.GetEnumString(DeliveryReportType.Value)));
+                    new KeyValuePair<string, string>("type",DeliveryReportType.Value));
             }
 
             if (Statuses is not null && Statuses.Count > 0)

--- a/src/Sinch/SMS/DeliveryReports/List/Request.cs
+++ b/src/Sinch/SMS/DeliveryReports/List/Request.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Sinch.Core;
 
 namespace Sinch.SMS.DeliveryReports.List
@@ -24,20 +25,21 @@ namespace Sinch.SMS.DeliveryReports.List
         {
             var kvp = new List<KeyValuePair<string, string>>();
             kvp.Add(new KeyValuePair<string, string>("page", Page.ToString()));
-            
+
             if (PageSize.HasValue)
             {
                 kvp.Add(new KeyValuePair<string, string>("page_size", PageSize.Value.ToString()));
             }
 
-            
+
             if (StartDate.HasValue)
                 kvp.Add(new KeyValuePair<string, string>("start_date", StringUtils.ToIso8601(StartDate.Value)));
 
             if (EndDate.HasValue)
                 kvp.Add(new KeyValuePair<string, string>("end_date", StringUtils.ToIso8601(EndDate.Value)));
 
-            if (Status is not null) kvp.Add(new KeyValuePair<string, string>("status", string.Join(",", Status)));
+            if (Status is not null)
+                kvp.Add(new KeyValuePair<string, string>("status", string.Join(",", Status.Select(x => x.Value))));
 
             if (Code is not null) kvp.Add(new KeyValuePair<string, string>("code", string.Join(",", Code)));
 

--- a/src/Sinch/SMS/Hooks/RecipientDeliveryReport.cs
+++ b/src/Sinch/SMS/Hooks/RecipientDeliveryReport.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 using Sinch.Core;
 using Sinch.SMS.DeliveryReports;
@@ -86,13 +85,20 @@ namespace Sinch.SMS.Hooks
         public DateTime OperatorStatusName { get; set; }
     }
 
-    [JsonConverter(typeof(SinchEnumConverter<Encoding>))]
-    public enum Encoding
+    /// <summary>
+    ///     Represents the encoding options for SMS.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<Encoding>))]
+    public record Encoding(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "GSM")]
-        Gsm,
+        /// <summary>
+        ///     Represents the GSM encoding.
+        /// </summary>
+        public static readonly Encoding Gsm = new("GSM");
 
-        [EnumMember(Value = "UNICODE")]
-        Unicode
+        /// <summary>
+        ///     Represents the Unicode encoding.
+        /// </summary>
+        public static readonly Encoding Unicode = new("UNICODE");
     }
 }

--- a/src/Sinch/SMS/Inbounds/SmsType.cs
+++ b/src/Sinch/SMS/Inbounds/SmsType.cs
@@ -1,16 +1,27 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.SMS.Inbounds
 {
-    [JsonConverter(typeof(SinchEnumConverter<SmsType>))]
-    public enum SmsType
+    /// <summary>
+    ///     Represents the SMS type options.
+    /// </summary>
+    [JsonConverter(typeof(EnumRecordJsonConverter<SmsType>))]
+    public record SmsType(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "mo_text")]
-        Text,
+        /// <summary>
+        ///     Represents a text SMS type.
+        /// </summary>
+        public static readonly SmsType Text = new("mo_text");
 
-        [EnumMember(Value = "mo_binary")]
-        Binary
+        /// <summary>
+        ///     Represents a binary SMS type.
+        /// </summary>
+        public static readonly SmsType Binary = new("mo_binary");
+
+        public override string ToString()
+        {
+            return base.ToString();
+        }
     }
 }

--- a/src/Sinch/SMS/SmsRegion.cs
+++ b/src/Sinch/SMS/SmsRegion.cs
@@ -6,31 +6,31 @@
     ///     If you want access to servers in other parts of the world, contact your Sinch account manager.
     ///     Customer Data will be stored in the corresponding locations listed below.
     /// </summary>
-    public enum SmsRegion
+    public record SmsRegion(string Value)
     {
         /// <summary>
         ///     USA
         /// </summary>
-        Us,
+        public static readonly SmsRegion Us = new("Us");
 
         /// <summary>
         ///     Ireland, Sweden
         /// </summary>
-        Eu,
+        public static readonly SmsRegion Eu = new("Eu");
 
         /// <summary>
         ///     Australia
         /// </summary>
-        Au,
+        public static readonly SmsRegion Au = new("Au");
 
         /// <summary>
         ///     Brazil
         /// </summary>
-        Br,
+        public static readonly SmsRegion Br = new("Br");
 
         /// <summary>
         ///     Canada
         /// </summary>
-        Ca
+        public static readonly SmsRegion Ca = new("Ca");
     }
 }

--- a/src/Sinch/SMS/SmsType.cs
+++ b/src/Sinch/SMS/SmsType.cs
@@ -1,16 +1,12 @@
-﻿using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Sinch.Core;
 
 namespace Sinch.SMS
 {
-    [JsonConverter(typeof(SinchEnumConverter<SmsType>))]
-    public enum SmsType
+    [JsonConverter(typeof(EnumRecordJsonConverter<SmsType>))]
+    public record SmsType(string Value) : EnumRecord(Value)
     {
-        [EnumMember(Value = "mt_text")]
-        MtText,
-
-        [EnumMember(Value = "mt_binary")]
-        MtBinary
+        public static readonly SmsType MtText = new ("mt_text");
+        public static readonly SmsType MtBinary = new ("mt_binary");
     }
 }

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -4,9 +4,9 @@ using System.Text.Json;
 using Sinch.Auth;
 using Sinch.Conversation;
 using Sinch.Core;
+using Sinch.Logger;
 using Sinch.Numbers;
 using Sinch.SMS;
-using LoggerFactory = Sinch.Logger.LoggerFactory;
 
 namespace Sinch
 {
@@ -113,7 +113,7 @@ namespace Sinch
 
             Conversation = new Conversation.Conversation(projectId,
                 new Uri(
-                    $"https://{optionsObj.ConversationRegion.ToString().ToLowerInvariant()}.conversation.api.sinch.com/"),
+                    $"https://{optionsObj.ConversationRegion.Value}.conversation.api.sinch.com/"),
                 _loggerFactory, httpSnakeCase);
 
             Auth = auth;
@@ -152,10 +152,9 @@ namespace Sinch
         {
             return smsRegion switch
             {
-                SmsRegion.Us or SmsRegion.Ca or SmsRegion.Br => "us",
-                SmsRegion.Eu or SmsRegion.Au => "eu",
-                // unreachable
-                _ => throw new ArgumentOutOfRangeException(nameof(smsRegion), smsRegion, "Region is not supported")
+                _ when smsRegion == SmsRegion.Us || smsRegion == SmsRegion.Ca || smsRegion == SmsRegion.Br => "us",
+                _ when smsRegion == SmsRegion.Eu || smsRegion == SmsRegion.Au => "eu",
+                _ => smsRegion.Value
             };
         }
 
@@ -164,7 +163,7 @@ namespace Sinch
 
         /// <inheritdoc/>
         public ISms Sms { get; }
-        
+
         /// <inheritdoc/>
         public IConversation Conversation { get; set; }
 

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -68,7 +68,7 @@ namespace Sinch.Tests.Numbers
         public async Task ListWithFullParams()
         {
             var url = $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers?regionCode=US&type=LOCAL";
-            url += "&numberPattern.pattern=2020&numberPattern.searchPattern=CONTAIN";
+            url += "&numberPattern.pattern=2020&numberPattern.searchPattern=CONTAINS";
             url += "&capability=SMS&capability=VOICE";
             url += "&pageSize=128";
             url += "&pageToken=i32dsan";
@@ -85,6 +85,7 @@ namespace Sinch.Tests.Numbers
                     nextPageToken = "004",
                     totalSize = 5
                 }));
+            
             var request = new Request
             {
                 RegionCode = "US",

--- a/tests/Sinch.Tests/Numbers/HooksTests.cs
+++ b/tests/Sinch.Tests/Numbers/HooksTests.cs
@@ -26,5 +26,25 @@ namespace Sinch.Tests.Numbers
             @enum.EventType.Should().Be(EventType.LinkTo10DlcCampaign);
             @enum.FailureCode.Should().Be(FailureCode.CampaignNotAvailable);
         }
+        
+        [Fact]
+        public void DeserializeEventWithCustomEnum()
+        {
+            const string jsonInput = @"
+            {
+                ""eventId"": ""abcd1234efghijklmnop567890"",
+                ""timestamp"": ""2023-06-06T07:45:27.785357"",
+                ""projectId"": ""abcd12ef-ab12-ab12-bc34-abcdef123456"",
+                ""resourceId"": ""+12345612345"",
+                ""resourceType"": ""NUMBER"",
+                ""eventType"": ""UNEXPECTED_ENUM_TYPE"",
+                ""status"": ""FAILED"",
+                ""failureCode"": ""CAMPAIGN_NOT_AVAILABLE""
+            }";
+            var @enum = JsonSerializer.Deserialize<Event>(jsonInput)!;
+            @enum.Status.Should().Be(EventStatus.Failed);
+            @enum.EventType.Should().Be(new EventType("UNEXPECTED_ENUM_TYPE"));
+            @enum.FailureCode.Should().Be(FailureCode.CampaignNotAvailable);
+        }
     }
 }

--- a/tests/Sinch.Tests/Sms/BatchesTests.cs
+++ b/tests/Sinch.Tests/Sms/BatchesTests.cs
@@ -30,7 +30,7 @@ namespace Sinch.Tests.Sms
                 }
             },
             body = "Hi ${name}! How are you?",
-            type = "mt_text",
+            type = "mt_binary",
             created_at = "2019-08-24T14:15:22Z",
             modified_at = "2019-08-24T14:15:22Z",
             delivery_report = "full",
@@ -93,6 +93,7 @@ namespace Sinch.Tests.Sms
                 { "default_value", "irythil" }
             });
             response.DeliveryReport.Should().Be(DeliveryReport.Full);
+            response.Type.Should().Be(SmsType.MtBinary);
         }
 
         [Fact]

--- a/tests/Sinch.Tests/Sms/DeliveryReportsTests.cs
+++ b/tests/Sinch.Tests/Sms/DeliveryReportsTests.cs
@@ -18,15 +18,15 @@ namespace Sinch.Tests.Sms
         [Fact]
         public void DeliveryReportStatusToString()
         {
-            var enumStr = DeliveryReportStatus.Aborted.ToString();
+            var enumStr = DeliveryReportStatus.Aborted;
 
-            enumStr.Should().Be("Aborted");
+            enumStr.Value.Should().Be("Aborted");
         }
 
         [Fact]
         public void DeliveryReportStatusFromString()
         {
-            var @enum = Enum.Parse<DeliveryReportStatus>("Delivered");
+            var @enum = new DeliveryReportStatus("Delivered");
 
             @enum.Should().Be(DeliveryReportStatus.Delivered);
         }


### PR DESCRIPTION
Enums are too strict and can throw runtime error if API enum values where extended, but SDK is behind the update. 
Record provide the ability to use any enum string and provide access to predefined values as `static readonly` fields. 