### PR TITLE
feat: add application signed authentication

### DIFF
--- a/examples/Console/Program.cs
+++ b/examples/Console/Program.cs
@@ -1,5 +1,6 @@
 ﻿using DotNetEnv;
 using Sinch;
+using Sinch.Verification;
 
 // Assume .env file is present in your output directory
 Env.Load();
@@ -9,6 +10,6 @@ var sinch = new SinchClient(Environment.GetEnvironmentVariable("SINCH_KEY_ID")!,
     Environment.GetEnvironmentVariable("SINCH_PROJECT_ID")!);
 
 var verification = sinch.Verification(Environment.GetEnvironmentVariable("SINCH_APP_KEY")!,
-    Environment.GetEnvironmentVariable("SINCH_APP_SECRET")!);
+    Environment.GetEnvironmentVariable("SINCH_APP_SECRET")!, AuthStrategy.ApplicationSign);
 
 Console.ReadLine();

--- a/src/Sinch/Auth/ApplicationSignedAuth.cs
+++ b/src/Sinch/Auth/ApplicationSignedAuth.cs
@@ -15,6 +15,8 @@ namespace Sinch.Auth
         private string _requestPath;
         private string _timestamp;
 
+        public string Scheme { get; } = "Application";
+
         public ApplicationSignedAuth(string appKey, string appSecret)
         {
             _appSecret = appSecret;
@@ -31,8 +33,6 @@ namespace Sinch.Auth
             _requestContentType = contentType;
             return GetAuthValue().GetAwaiter().GetResult();
         }
-
-        public string Scheme { get; } = "Application";
 
 
         public Task<string> GetAuthValue(bool force = false)

--- a/src/Sinch/Auth/ApplicationSignedAuth.cs
+++ b/src/Sinch/Auth/ApplicationSignedAuth.cs
@@ -1,17 +1,59 @@
 ﻿using System;
+using System.Security.Cryptography;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Sinch.Auth
 {
     public class ApplicationSignedAuth : IAuth
     {
-        public Task<string> GetAuthValue(bool force = false)
-        {
+        private readonly string _appSecret;
+        private readonly string _appKey;
+        private byte[] _jsonBodyInBytes;
+        private string _httpVerb;
+        private string _requestContentType = "application/json; charset=UTF-8";
+        private string _requestPath;
+        private string _timestamp;
 
-            // TODO: implement application signed auth
-            throw new NotImplementedException();
+        public ApplicationSignedAuth(string appKey, string appSecret)
+        {
+            _appSecret = appSecret;
+            _appKey = appKey;
         }
 
-        public string Scheme { get; }
+        public string GetSignedAuth(byte[] jsonBodyBytes, string httpVerb,
+            string requestPath, string timestamp, string contentType)
+        {
+            _jsonBodyInBytes = jsonBodyBytes;
+            _httpVerb = httpVerb;
+            _requestPath = requestPath;
+            _timestamp = timestamp;
+            _requestContentType = contentType;
+            return GetAuthValue().GetAwaiter().GetResult();
+        }
+
+        public string Scheme { get; } = "Application";
+
+
+        public Task<string> GetAuthValue(bool force = false)
+        {
+            var encodedBody = string.Empty;
+            if (_jsonBodyInBytes is not null)
+            {
+                var md5Bytes = MD5.HashData(_jsonBodyInBytes);
+                encodedBody = Convert.ToBase64String(md5Bytes);
+            }
+
+            var toSign = new StringBuilder().AppendJoin('\n', _httpVerb.ToUpperInvariant(), encodedBody,
+                _requestContentType,
+                _timestamp, _requestPath).ToString();
+
+            using var hmac = new HMACSHA256(Convert.FromBase64String(_appSecret));
+            var hmacSha256 = hmac.ComputeHash(Encoding.UTF8.GetBytes(toSign));
+
+            var authSignature = Convert.ToBase64String(hmacSha256);
+
+            return Task.FromResult($"{_appKey}:{authSignature}");
+        }
     }
 }

--- a/src/Sinch/Auth/ApplicationSignedAuth.cs
+++ b/src/Sinch/Auth/ApplicationSignedAuth.cs
@@ -11,7 +11,7 @@ namespace Sinch.Auth
         private readonly string _appKey;
         private byte[] _jsonBodyInBytes;
         private string _httpVerb;
-        private string _requestContentType = "application/json; charset=UTF-8";
+        private string _requestContentType;
         private string _requestPath;
         private string _timestamp;
 

--- a/src/Sinch/Auth/BasicAuth.cs
+++ b/src/Sinch/Auth/BasicAuth.cs
@@ -9,11 +9,12 @@ namespace Sinch.Auth
         private readonly string _appKey;
         private readonly string _appSecret;
 
+        public string Scheme { get; } = "Basic";
+
         public BasicAuth(string appKey, string appSecret)
         {
             _appKey = appKey;
             _appSecret = appSecret;
-            Scheme = "Basic";
         }
 
         public Task<string> GetAuthValue(bool force = false)
@@ -21,7 +22,5 @@ namespace Sinch.Auth
             var plainTextBytes = Encoding.UTF8.GetBytes($"{_appKey}:{_appSecret}");
             return Task.FromResult(Convert.ToBase64String(plainTextBytes));
         }
-
-        public string Scheme { get; }
     }
 }

--- a/src/Sinch/Auth/OAuth.cs
+++ b/src/Sinch/Auth/OAuth.cs
@@ -21,6 +21,8 @@ namespace Sinch.Auth
         private volatile string _token;
         private readonly Uri _baseAddress;
 
+        public string Scheme { get; } = "Bearer";
+
         public OAuth(string keyId, string keySecret, HttpClient httpClient, ILoggerAdapter<OAuth> logger)
         {
             _keyId = keyId;
@@ -28,7 +30,6 @@ namespace Sinch.Auth
             _httpClient = httpClient;
             _logger = logger;
             _baseAddress = new Uri("https://auth.sinch.com");
-            Scheme = "Bearer";
         }
 
         internal OAuth(Uri baseAddress, HttpClient httpClient) : this("", "", httpClient, null)
@@ -86,8 +87,6 @@ namespace Sinch.Auth
             _logger?.LogInformation("Retrieved new token which will expire in {expire}", _expiresIn);
             return _token;
         }
-
-        public string Scheme { get; }
 
         private class AuthResponse
         {

--- a/src/Sinch/Conversation/Apps/Apps.cs
+++ b/src/Sinch/Conversation/Apps/Apps.cs
@@ -99,7 +99,7 @@ namespace Sinch.Conversation.Apps
         {
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps");
             _logger?.LogDebug("Creating an app...");
-            return _http.Send<Request, App>(uri, HttpMethod.Post, request, cancellationToken);
+            return _http.Send<Request, App>(uri, HttpMethod.Post, request, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc />
@@ -107,7 +107,7 @@ namespace Sinch.Conversation.Apps
         {
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps");
             _logger?.LogDebug("Listing apps for a {projectId}", _projectId);
-            var response = await _http.Send<ListResponse>(uri, HttpMethod.Get, cancellationToken);
+            var response = await _http.Send<ListResponse>(uri, HttpMethod.Get, cancellationToken: cancellationToken);
             return response.Apps;
         }
 
@@ -123,7 +123,7 @@ namespace Sinch.Conversation.Apps
 
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps/{appId}");
             _logger?.LogDebug("Getting an app for a {projectId} with {appId}", _projectId, appId);
-            return _http.Send<App>(uri, HttpMethod.Get, cancellationToken);
+            return _http.Send<App>(uri, HttpMethod.Get, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc />
@@ -138,7 +138,7 @@ namespace Sinch.Conversation.Apps
 
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps/{appId}");
             _logger?.LogDebug("Deleting an app for a {projectId} with {appId}", _projectId, appId);
-            return _http.Send<object>(uri, HttpMethod.Delete, cancellationToken);
+            return _http.Send<object>(uri, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc />
@@ -158,7 +158,8 @@ namespace Sinch.Conversation.Apps
 
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps/{appId}{query}");
             _logger?.LogDebug("Updating an app for a {projectId} with {appId}", _projectId, appId);
-            return _http.Send<Update.Request, App>(uri, HttpMethod.Patch, request, cancellationToken);
+            return _http.Send<Update.Request, App>(uri, HttpMethod.Patch, request,
+                cancellationToken: cancellationToken);
         }
 
         private class ListResponse

--- a/src/Sinch/Conversation/Messages/Messages.cs
+++ b/src/Sinch/Conversation/Messages/Messages.cs
@@ -93,7 +93,7 @@ namespace Sinch.Conversation.Messages
         {
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/messages:send");
             _logger?.LogDebug("Sending a message...");
-            return _http.Send<Request, Response>(uri, HttpMethod.Post, request, cancellationToken);
+            return _http.Send<Request, Response>(uri, HttpMethod.Post, request, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc/>  
@@ -104,7 +104,7 @@ namespace Sinch.Conversation.Messages
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/messages/{messageId}{param}");
 
             _logger?.LogDebug("Getting a message with {messageId}...", messageId);
-            return _http.Send<ConversationMessage>(uri, HttpMethod.Get, cancellationToken);
+            return _http.Send<ConversationMessage>(uri, HttpMethod.Get, cancellationToken: cancellationToken);
         }
 
         private static string GetMessageSourceQueryParam(MessageSource messagesSource)
@@ -121,7 +121,7 @@ namespace Sinch.Conversation.Messages
             _logger?.LogDebug("Fetching list of messages {request}", request);
             var uri = new Uri(_baseAddress,
                 $"v1/projects/{_projectId}/messages?{Utils.ToSnakeCaseQueryString(request)}");
-            return _http.Send<List.Response>(uri, HttpMethod.Get, cancellationToken);
+            return _http.Send<List.Response>(uri, HttpMethod.Get, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc/>  
@@ -132,7 +132,7 @@ namespace Sinch.Conversation.Messages
             _logger?.LogDebug("Deleting a message {messageId}", messageId);
             var uri = new Uri(_baseAddress,
                 $"v1/projects/{_projectId}/messages/{messageId}{param}");
-            return _http.Send<object>(uri, HttpMethod.Delete, cancellationToken);
+            return _http.Send<object>(uri, HttpMethod.Delete, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Sinch/Verification/AuthStrategy.cs
+++ b/src/Sinch/Verification/AuthStrategy.cs
@@ -1,0 +1,15 @@
+﻿namespace Sinch.Verification
+{
+    public enum AuthStrategy
+    {
+        /// <summary>
+        ///     Utilizes only AppId and AppSecret
+        /// </summary>
+        Basic,
+        
+        /// <summary>
+        ///     Utilizes <see href="https://developers.sinch.com/docs/verification/api-reference/authentication/signed-request/">Request Signing</see>
+        /// </summary>
+        ApplicationSign,
+    }
+}

--- a/src/Sinch/Verification/Report/Response/VerificationReportResponseBase.cs
+++ b/src/Sinch/Verification/Report/Response/VerificationReportResponseBase.cs
@@ -62,7 +62,24 @@ namespace Sinch.Verification.Report.Response
         public override void Write(Utf8JsonWriter writer, IVerificationReportResponse value,
             JsonSerializerOptions options)
         {
-            JsonSerializer.Serialize(writer, value, options);
+            switch (value)
+            {
+                case FlashCallVerificationReportResponse flashCallVerificationReportResponse:
+                    JsonSerializer.Serialize(
+                        writer, flashCallVerificationReportResponse, options);
+                    break;
+                case PhoneCallVerificationReportResponse phoneCallVerificationReportResponse:
+                    JsonSerializer.Serialize(
+                        writer, phoneCallVerificationReportResponse, options);
+                    break;
+                case SmsVerificationReportResponse smsVerificationReportResponse:
+                    JsonSerializer.Serialize(
+                        writer, smsVerificationReportResponse, options);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(value),
+                        $"Cannot find a proper specific type for {nameof(IVerificationReportResponse)}");
+            }
         }
     }
 }

--- a/src/Sinch/Verification/SinchVerification.cs
+++ b/src/Sinch/Verification/SinchVerification.cs
@@ -6,7 +6,6 @@ using Sinch.Core;
 using Sinch.Logger;
 using Sinch.Verification.Report;
 using Sinch.Verification.Report.Response;
-using Sinch.Verification.Start;
 using Sinch.Verification.Start.Request;
 using Sinch.Verification.Start.Response;
 
@@ -68,7 +67,7 @@ namespace Sinch.Verification
             var uri = new Uri(_baseAddress, $"verification/v1/verifications");
             _logger?.LogDebug("Starting verification...");
             return _http.Send<VerificationStartRequest, IVerificationStartResponse>(uri, HttpMethod.Post, request,
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
 
         public Task<IVerificationReportResponse> ReportIdentity(string endpoint, IVerifyReportRequest request,
@@ -97,16 +96,16 @@ namespace Sinch.Verification
                 FlashCallVerificationReportRequest flashCallVerificationReportRequest =>
                     _http.Send<FlashCallVerificationReportRequest, IVerificationReportResponse>(uri, HttpMethod.Put,
                         flashCallVerificationReportRequest,
-                        cancellationToken),
+                        cancellationToken: cancellationToken),
                 SmsVerificationReportRequest smsVerificationRequest => _http
                     .Send<SmsVerificationReportRequest, IVerificationReportResponse>(
                         uri, HttpMethod.Put,
                         smsVerificationRequest,
-                        cancellationToken),
+                        cancellationToken: cancellationToken),
                 PhoneCallVerificationReportRequest phoneRequest => _http
                     .Send<PhoneCallVerificationReportRequest, IVerificationReportResponse>(uri, HttpMethod.Put,
                         phoneRequest,
-                        cancellationToken),
+                        cancellationToken: cancellationToken),
                 _ => throw new ArgumentOutOfRangeException(nameof(request))
             };
         }

--- a/src/Sinch/Verification/SinchVerificationClient.cs
+++ b/src/Sinch/Verification/SinchVerificationClient.cs
@@ -22,16 +22,9 @@ namespace Sinch.Verification
 
     internal class SinchVerificationClient : ISinchVerificationClient
     {
-        // TODO: utilize with application signed authentication
-        private readonly string _appKey;
-        private readonly string _appSecret;
-
-        internal SinchVerificationClient(string appKey, string appSecret, Uri baseAddress, LoggerFactory loggerFactory,
+        internal SinchVerificationClient(Uri baseAddress, LoggerFactory loggerFactory,
             IHttp http)
         {
-            _appKey = appKey;
-            _appSecret = appSecret;
-
             Verification = new SinchVerification(loggerFactory?.Create<SinchVerification>(), baseAddress, http);
             VerificationStatus =
                 new SinchVerificationStatus(loggerFactory?.Create<SinchVerificationStatus>(), baseAddress, http);

--- a/src/Sinch/Verification/SinchVerificationStatus.cs
+++ b/src/Sinch/Verification/SinchVerificationStatus.cs
@@ -60,7 +60,7 @@ namespace Sinch.Verification
             var uri = new Uri(_baseAddress, $"verification/v1/verifications/id/{id}");
             _logger?.LogDebug("Getting status of the verification by {id}", id);
             return _http.Send<IVerificationReportResponse>(uri, HttpMethod.Get,
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
 
         public Task<IVerificationReportResponse> GetByIdentity(string endpoint, VerificationMethod method,
@@ -70,7 +70,7 @@ namespace Sinch.Verification
             _logger?.LogDebug("Getting status of the verification by identity {endpoint} and {method}", endpoint,
                 method);
             return _http.Send<IVerificationReportResponse>(uri, HttpMethod.Get,
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
 
         public Task<IVerificationReportResponse> GetByReference(string reference,
@@ -79,7 +79,7 @@ namespace Sinch.Verification
             var uri = new Uri(_baseAddress, $"verification/v1/verifications/reference/{reference}");
             _logger?.LogDebug("Getting status of the verification by {reference}", reference);
             return _http.Send<IVerificationReportResponse>(uri, HttpMethod.Get,
-                cancellationToken);
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/tests/Sinch.Tests/Verification/VerificationTestBase.cs
+++ b/tests/Sinch.Tests/Verification/VerificationTestBase.cs
@@ -9,7 +9,7 @@ namespace Sinch.Tests.Verification
 
         protected VerificationTestBase()
         {
-            VerificationClient = new SinchVerificationClient("app_key", "app_secret",
+            VerificationClient = new SinchVerificationClient(
                 new Uri("https://verification.api.sinch.com/"), null, HttpCamelCase);
         }
     }

--- a/tests/Sinch.Tests/e2e/Verification/VerificationTestBase.cs
+++ b/tests/Sinch.Tests/e2e/Verification/VerificationTestBase.cs
@@ -8,7 +8,7 @@ namespace Sinch.Tests.e2e.Verification
 
         public VerificationTestBase()
         {
-            VerificationClient = SinchClientMockServer.Verification("app_key", "app_secret");
+            VerificationClient = SinchClientMockServer.Verification("app_key", "app_secret", AuthStrategy.Basic);
         }
     }
 }

--- a/tests/Sinch.Tests/e2e/Verification/VerificationTestBase.cs
+++ b/tests/Sinch.Tests/e2e/Verification/VerificationTestBase.cs
@@ -6,7 +6,7 @@ namespace Sinch.Tests.e2e.Verification
     {
         protected readonly ISinchVerificationClient VerificationClient;
 
-        public VerificationTestBase()
+        protected VerificationTestBase()
         {
             VerificationClient = SinchClientMockServer.Verification("app_key", "app_secret", AuthStrategy.Basic);
         }


### PR DESCRIPTION
Adds support for https://developers.sinch.com/docs/verification/api-reference/authentication/signed-request/ authentication for sdk and allows the user to change it. 
I'm aware that in Http.css checking for specific type in interface is not fully OOP SOLID(you name it) compliant, but it makes sense to keep it grouped and not to drag the implementation and http factories across whole dependency stack. 