### PR TITLE
Fix/update sms hosting region

### DIFF
--- a/src/Sinch/SMS/SmsHostingRegion.cs
+++ b/src/Sinch/SMS/SmsHostingRegion.cs
@@ -3,16 +3,16 @@
     /// <summary>
     ///     The following regions can be set to be used in SDK as a hosting region.
     /// </summary>
-    public record SmsRegion(string Value)
+    public record SmsHostingRegion(string Value)
     {
         /// <summary>
         ///     USA
         /// </summary>
-        public static readonly SmsRegion Us = new("Us");
+        public static readonly SmsHostingRegion Us = new("Us");
 
         /// <summary>
         ///     Ireland, Sweden
         /// </summary>
-        public static readonly SmsRegion Eu = new("Eu");
+        public static readonly SmsHostingRegion Eu = new("Eu");
     }
 }

--- a/src/Sinch/SMS/SmsRegion.cs
+++ b/src/Sinch/SMS/SmsRegion.cs
@@ -1,10 +1,7 @@
 ﻿namespace Sinch.SMS
 {
     /// <summary>
-    ///     The following regions can be set to be used in SDK.
-    ///     By default, your account will be created in the US environment.
-    ///     If you want access to servers in other parts of the world, contact your Sinch account manager.
-    ///     Customer Data will be stored in the corresponding locations listed below.
+    ///     The following regions can be set to be used in SDK as a hosting region.
     /// </summary>
     public record SmsRegion(string Value)
     {
@@ -17,20 +14,5 @@
         ///     Ireland, Sweden
         /// </summary>
         public static readonly SmsRegion Eu = new("Eu");
-
-        /// <summary>
-        ///     Australia
-        /// </summary>
-        public static readonly SmsRegion Au = new("Au");
-
-        /// <summary>
-        ///     Brazil
-        /// </summary>
-        public static readonly SmsRegion Br = new("Br");
-
-        /// <summary>
-        ///     Canada
-        /// </summary>
-        public static readonly SmsRegion Ca = new("Ca");
     }
 }

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -146,7 +146,7 @@ namespace Sinch
 
             Numbers = new Numbers.Numbers(projectId, new Uri(NumbersApiUrl),
                 _loggerFactory, httpCamelCase);
-            Sms = new Sms(projectId, GetSmsBaseAddress(optionsObj.SmsRegion), _loggerFactory,
+            Sms = new Sms(projectId, GetSmsBaseAddress(optionsObj.SmsHostingRegion), _loggerFactory,
                 httpSnakeCase);
             Conversation = new Conversation.Conversation(projectId,
                 new Uri(string.Format(ConversationApiUrlTemplate, optionsObj.ConversationRegion.Value)),
@@ -159,15 +159,11 @@ namespace Sinch
 
         private static Uri GetSmsBaseAddress(SmsRegion smsRegion)
         {
-            // only three regions are available for single-account model. it's eu and us. 
-            // So, we should map other regions provided in docs to nearest server.
-            // See: https://developers.sinch.com/docs/sms/api-reference/#base-url
-            var smsRegionStr = GetSmsRegion(smsRegion);
             // General SMS rest api uses service_plan_id to performs calls
             // But SDK is based on single-account model which uses project_id
             // Thus, baseAddress for sms api is using a special endpoint where service_plan_id is replaced with projectId
             // for each provided endpoint
-            return new Uri(string.Format(SmsApiUrlTemplate, smsRegionStr));
+            return new Uri(string.Format(SmsApiUrlTemplate, smsRegion.Value.ToLowerInvariant()));
         }
 
         /// <summary>
@@ -190,24 +186,6 @@ namespace Sinch
             Numbers = new Numbers.Numbers(projectId, numbersBaseAddress, null, httpCamelCase);
             Sms = new Sms(projectId, smsBaseAddress, null, httpSnakeCase);
             _verificationBaseAddress = verificationBaseAddress;
-        }
-
-        /// <summary>
-        ///     Only two regions are available for single-account model. it's eu, us.
-        ///     So, we should map other regions provided in docs to nearest server.
-        ///     See: https://developers.sinch.com/docs/sms/api-reference/#base-url
-        /// </summary>
-        /// <param name="smsRegion"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentOutOfRangeException"></exception>
-        private static string GetSmsRegion(SmsRegion smsRegion)
-        {
-            return smsRegion switch
-            {
-                _ when smsRegion == SmsRegion.Us || smsRegion == SmsRegion.Ca || smsRegion == SmsRegion.Br => "us",
-                _ when smsRegion == SmsRegion.Eu || smsRegion == SmsRegion.Au => "eu",
-                _ => smsRegion.Value
-            };
         }
 
         /// <inheritdoc/>       

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -157,13 +157,13 @@ namespace Sinch
             logger?.LogInformation("SinchClient initialized.");
         }
 
-        private static Uri GetSmsBaseAddress(SmsRegion smsRegion)
+        private static Uri GetSmsBaseAddress(SmsHostingRegion smsHostingRegion)
         {
             // General SMS rest api uses service_plan_id to performs calls
             // But SDK is based on single-account model which uses project_id
             // Thus, baseAddress for sms api is using a special endpoint where service_plan_id is replaced with projectId
             // for each provided endpoint
-            return new Uri(string.Format(SmsApiUrlTemplate, smsRegion.Value.ToLowerInvariant()));
+            return new Uri(string.Format(SmsApiUrlTemplate, smsHostingRegion.Value.ToLowerInvariant()));
         }
 
         /// <summary>

--- a/src/Sinch/SinchOptions.cs
+++ b/src/Sinch/SinchOptions.cs
@@ -28,7 +28,7 @@ namespace Sinch
         ///     <br /><br />
         ///     Defaults to "us"
         /// </summary>
-        public SmsRegion SmsHostingRegion { get; set; } = SmsRegion.Us;
+        public SmsHostingRegion SmsHostingRegion { get; set; } = SmsHostingRegion.Us;
 
         /// <summary>
         ///     Set's the regions for the Conversation api.

--- a/src/Sinch/SinchOptions.cs
+++ b/src/Sinch/SinchOptions.cs
@@ -19,11 +19,16 @@ namespace Sinch
         public HttpClient HttpClient { get; set; }
 
         /// <summary>
-        ///     Set's the regions for the SMS api.
-        ///     <see href="https://developers.sinch.com/docs/sms/api-reference/#base-url">SMS base URL</see><br /><br />
+        ///     Set's the hosting region for the SMS service.
+        ///     <br/><br/>
+        ///     The difference between this option and
+        ///     <see href="https://developers.sinch.com/docs/sms/api-reference/#base-url">SMS base URL</see>
+        ///     is that your account is NOT region locked because SDK utilizes `project_id` API set instead of `service_plan_id`,
+        ///     and utilizes region to store the data.
+        ///     <br /><br />
         ///     Defaults to "us"
         /// </summary>
-        public SmsRegion SmsRegion { get; set; } = SmsRegion.Us;
+        public SmsRegion SmsHostingRegion { get; set; } = SmsRegion.Us;
 
         /// <summary>
         ///     Set's the regions for the Conversation api.


### PR DESCRIPTION
Update SmsRegion to SmsHostingRegion to clarify intentions of this option more clearly

Also, we have a plan to add support for _old_ SMS API model with `service_plan_id` and basic auth. 