### PR TITLE
Refactor/great renaming

### DIFF
--- a/examples/Console/RentAndConfigureNumbers.cs
+++ b/examples/Console/RentAndConfigureNumbers.cs
@@ -10,7 +10,7 @@ namespace Examples
         public static async Task Example()
         {
             var sinchClient = new SinchClient("KEY_ID", "KEY_SECRET", "PROJECT_ID");
-            var response = await sinchClient.Numbers.Available.Rent("+4811111111", new Request()
+            var response = await sinchClient.Numbers.Available.Rent("+4811111111", new RentActiveNumberRequest()
             {
                 SmsConfiguration = new SmsConfiguration
                 {

--- a/examples/WebApi/Controllers/InboundSmsController.cs
+++ b/examples/WebApi/Controllers/InboundSmsController.cs
@@ -11,10 +11,10 @@ namespace WebApiExamples.Controllers;
 [Route("reply")]
 public class InboundSmsController : ControllerBase
 {
-    private readonly ISinch _sinchClient;
+    private readonly ISinchClient _sinchClient;
     private readonly ILogger _logger;
 
-    public InboundSmsController(ISinch sinchClient, ILogger<InboundSmsController> logger)
+    public InboundSmsController(ISinchClient sinchClient, ILogger<InboundSmsController> logger)
     {
         _sinchClient = sinchClient;
         _logger = logger;

--- a/examples/WebApi/Controllers/InboundSmsController.cs
+++ b/examples/WebApi/Controllers/InboundSmsController.cs
@@ -24,7 +24,7 @@ public class InboundSmsController : ControllerBase
     [Route("subscription")]
     public async Task Subscribe([FromBody] IncomingTextSms incomingSms)
     {
-        var group = await _sinchClient.Sms.Groups.Create(new Request() { Name = "Pirates of Sinch" });
+        var group = await _sinchClient.Sms.Groups.Create(new CreateGroupRequest() { Name = "Pirates of Sinch" });
         var fromNumber = incomingSms.From;
         var toNumber = incomingSms.To;
         var autoReply = "";
@@ -34,7 +34,7 @@ public class InboundSmsController : ControllerBase
         switch (groupNumbers.Contains(fromNumber), inboundMessage)
         {
             case (false, "SUBSCRIBE"):
-                await _sinchClient.Sms.Groups.Update(new Sinch.SMS.Groups.Update.Request
+                await _sinchClient.Sms.Groups.Update(new Sinch.SMS.Groups.Update.UpdateGroupRequest
                     {
                         GroupId = group.Id,
                         Name = "group 1",
@@ -47,7 +47,7 @@ public class InboundSmsController : ControllerBase
                 autoReply = $"Congratulations! You are now subscribed to {group.Name}. Text STOP to leave this group.";
                 break;
             case (true, "STOP"):
-                await _sinchClient.Sms.Groups.Update(new Sinch.SMS.Groups.Update.Request
+                await _sinchClient.Sms.Groups.Update(new Sinch.SMS.Groups.Update.UpdateGroupRequest
                 {
                     GroupId = group.Id,
                     Name = "group 1",

--- a/examples/WebApi/Controllers/InboundSmsController.cs
+++ b/examples/WebApi/Controllers/InboundSmsController.cs
@@ -1,7 +1,9 @@
 ﻿using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Sinch;
+using Sinch.SMS.Batches.Send;
 using Sinch.SMS.Groups.Create;
+using Sinch.SMS.Groups.Update;
 using Sinch.SMS.Hooks;
 using DeliveryReport = Sinch.SMS.DeliveryReport;
 
@@ -34,7 +36,7 @@ public class InboundSmsController : ControllerBase
         switch (groupNumbers.Contains(fromNumber), inboundMessage)
         {
             case (false, "SUBSCRIBE"):
-                await _sinchClient.Sms.Groups.Update(new Sinch.SMS.Groups.Update.UpdateGroupRequest
+                await _sinchClient.Sms.Groups.Update(new UpdateGroupRequest
                     {
                         GroupId = group.Id,
                         Name = "group 1",
@@ -47,7 +49,7 @@ public class InboundSmsController : ControllerBase
                 autoReply = $"Congratulations! You are now subscribed to {group.Name}. Text STOP to leave this group.";
                 break;
             case (true, "STOP"):
-                await _sinchClient.Sms.Groups.Update(new Sinch.SMS.Groups.Update.UpdateGroupRequest
+                await _sinchClient.Sms.Groups.Update(new UpdateGroupRequest
                 {
                     GroupId = group.Id,
                     Name = "group 1",
@@ -65,7 +67,7 @@ public class InboundSmsController : ControllerBase
                 break;
         }
 
-        var response = await _sinchClient.Sms.Batches.Send(new Sinch.SMS.Batches.Send.SendBatchRequest
+        var response = await _sinchClient.Sms.Batches.Send(new SendBatchRequest
         {
             Body = autoReply,
             DeliveryReport = DeliveryReport.None,

--- a/examples/WebApi/Controllers/InboundSmsController.cs
+++ b/examples/WebApi/Controllers/InboundSmsController.cs
@@ -65,7 +65,7 @@ public class InboundSmsController : ControllerBase
                 break;
         }
 
-        var response = await _sinchClient.Sms.Batches.Send(new Sinch.SMS.Batches.Send.Request
+        var response = await _sinchClient.Sms.Batches.Send(new Sinch.SMS.Batches.Send.SendBatchRequest
         {
             Body = autoReply,
             DeliveryReport = DeliveryReport.None,

--- a/examples/WebApi/Controllers/Numbers.cs
+++ b/examples/WebApi/Controllers/Numbers.cs
@@ -8,9 +8,9 @@ namespace WebApiExamples.Controllers;
 [Route("[controller]")]
 public class Numbers : ControllerBase
 {
-    private readonly ISinch _sinch;
+    private readonly ISinchClient _sinch;
 
-    public Numbers(ISinch sinch)
+    public Numbers(ISinchClient sinch)
     {
         _sinch = sinch;
     }

--- a/examples/WebApi/Controllers/ReplyToInboundController.cs
+++ b/examples/WebApi/Controllers/ReplyToInboundController.cs
@@ -10,10 +10,10 @@ namespace WebApiExamples.Controllers;
 [Route("reply")]
 public class ReplyToInboundController : ControllerBase
 {
-    private readonly ISinch _sinch;
+    private readonly ISinchClient _sinch;
     private readonly ILogger _logger;
 
-    public ReplyToInboundController(ISinch sinch, ILogger<ReplyToInboundController> logger)
+    public ReplyToInboundController(ISinchClient sinch, ILogger<ReplyToInboundController> logger)
     {
         _sinch = sinch;
         _logger = logger;

--- a/examples/WebApi/Controllers/ReplyToInboundController.cs
+++ b/examples/WebApi/Controllers/ReplyToInboundController.cs
@@ -31,7 +31,7 @@ public class ReplyToInboundController : ControllerBase
             incomingSms.Body,
             incomingSms.From,
             incomingSms.To);
-        var _ = await _sinch.Sms.Batches.Send(new Request
+        var _ = await _sinch.Sms.Batches.Send(new SendBatchRequest
         {
             Body = incomingSms.Body,
             DeliveryReport = DeliveryReport.None,

--- a/examples/WebApi/Program.cs
+++ b/examples/WebApi/Program.cs
@@ -14,7 +14,7 @@ builder.Services.AddSwaggerGen();
 
 
 
-builder.Services.AddSingleton<ISinch>(_ => new SinchClient(
+builder.Services.AddSingleton<ISinchClient>(_ => new SinchClient(
     builder.Configuration["Sinch:KeyId"]!,
     builder.Configuration["Sinch:KeySecret"]!,
     builder.Configuration["Sinch:ProjectId"],

--- a/src/Sinch/Auth/ApplicationSignedAuth.cs
+++ b/src/Sinch/Auth/ApplicationSignedAuth.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Sinch.Auth
 {
-    public class ApplicationSignedAuth : ISinchAuth
+    internal class ApplicationSignedAuth : ISinchAuth
     {
         private readonly string _appSecret;
         private readonly string _appKey;

--- a/src/Sinch/Auth/ApplicationSignedAuth.cs
+++ b/src/Sinch/Auth/ApplicationSignedAuth.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Sinch.Auth
 {
-    public class ApplicationSignedAuth : IAuth
+    public class ApplicationSignedAuth : ISinchAuth
     {
         private readonly string _appSecret;
         private readonly string _appKey;

--- a/src/Sinch/Auth/BasicAuth.cs
+++ b/src/Sinch/Auth/BasicAuth.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Sinch.Auth
 {
-    public class BasicAuth : IAuth
+    public class BasicAuth : ISinchAuth
     {
         private readonly string _appKey;
         private readonly string _appSecret;

--- a/src/Sinch/Auth/BasicAuth.cs
+++ b/src/Sinch/Auth/BasicAuth.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Sinch.Auth
 {
-    public class BasicAuth : ISinchAuth
+    internal class BasicAuth : ISinchAuth
     {
         private readonly string _appKey;
         private readonly string _appSecret;

--- a/src/Sinch/Auth/ISinchAuth.cs
+++ b/src/Sinch/Auth/ISinchAuth.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.Auth
 {
-    public interface IAuth
+    public interface ISinchAuth
     {
         /// <summary>
         ///     Get an auth token.

--- a/src/Sinch/Auth/OAuth.cs
+++ b/src/Sinch/Auth/OAuth.cs
@@ -66,7 +66,7 @@ namespace Sinch.Auth
                 var authResponse = await result.TryGetJson<AuthApiError>();
                 _logger?.LogError("Failed to fetch a token with {status} dew to {reason}", result.StatusCode,
                     result.ReasonPhrase);
-                throw new AuthException(result.StatusCode, result.ReasonPhrase, null, authResponse);
+                throw new SinchAuthException(result.StatusCode, result.ReasonPhrase, null, authResponse);
             }
 
             var response = await result.Content.ReadFromJsonAsync<AuthResponse>();

--- a/src/Sinch/Auth/OAuth.cs
+++ b/src/Sinch/Auth/OAuth.cs
@@ -11,7 +11,7 @@ using Sinch.Logger;
 
 namespace Sinch.Auth
 {
-    internal class OAuth : IAuth
+    internal class OAuth : ISinchAuth
     {
         private readonly HttpClient _httpClient;
         private readonly string _keyId;

--- a/src/Sinch/Auth/SinchAuthException.cs
+++ b/src/Sinch/Auth/SinchAuthException.cs
@@ -4,14 +4,14 @@ using System.Net.Http;
 
 namespace Sinch.Auth
 {
-    public sealed class AuthException : HttpRequestException
+    public sealed class SinchAuthException : HttpRequestException
     {
-        private AuthException(HttpStatusCode statusCode, string message, Exception inner) : base(message, inner,
+        private SinchAuthException(HttpStatusCode statusCode, string message, Exception inner) : base(message, inner,
             statusCode)
         {
         }
 
-        internal AuthException(HttpStatusCode statusCode, string message, Exception inner, AuthApiError authApiError)
+        internal SinchAuthException(HttpStatusCode statusCode, string message, Exception inner, AuthApiError authApiError)
             : this(statusCode, message, inner)
         {
             Error = authApiError?.Error;

--- a/src/Sinch/Conversation/Apps/Apps.cs
+++ b/src/Sinch/Conversation/Apps/Apps.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Sinch.Conversation.Apps.Create;
+using Sinch.Conversation.Apps.Update;
 using Sinch.Core;
 using Sinch.Logger;
 
@@ -18,7 +19,7 @@ namespace Sinch.Conversation.Apps
     ///     for each underlying connected channel.
     ///     The app has a list of conversations between itself and different contacts which share the same project.
     /// </summary>
-    public interface IApp
+    public interface ISinchConversationApp
     {
         /// <summary>
         ///     You can create a new Conversation API app using the API.
@@ -28,7 +29,7 @@ namespace Sinch.Conversation.Apps
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<App> Create(Request request, CancellationToken cancellationToken = default);
+        Task<App> Create(CreateAppRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Get a list of all apps.
@@ -76,10 +77,10 @@ namespace Sinch.Conversation.Apps
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<App> Update(string appId, Update.Request request, CancellationToken cancellationToken = default);
+        Task<App> Update(string appId, UpdateAppRequest request, CancellationToken cancellationToken = default);
     }
 
-    internal class Apps : IApp
+    internal class Apps : ISinchConversationApp
     {
         private readonly Uri _baseAddress;
         private readonly IHttp _http;
@@ -95,11 +96,12 @@ namespace Sinch.Conversation.Apps
         }
 
         /// <inheritdoc />
-        public Task<App> Create(Request request, CancellationToken cancellationToken = default)
+        public Task<App> Create(CreateAppRequest request, CancellationToken cancellationToken = default)
         {
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps");
             _logger?.LogDebug("Creating an app...");
-            return _http.Send<Request, App>(uri, HttpMethod.Post, request, cancellationToken: cancellationToken);
+            return _http.Send<CreateAppRequest, App>(uri, HttpMethod.Post, request,
+                cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc />
@@ -107,6 +109,7 @@ namespace Sinch.Conversation.Apps
         {
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps");
             _logger?.LogDebug("Listing apps for a {projectId}", _projectId);
+            // flatten the response 
             var response = await _http.Send<ListResponse>(uri, HttpMethod.Get, cancellationToken: cancellationToken);
             return response.Apps;
         }
@@ -142,7 +145,7 @@ namespace Sinch.Conversation.Apps
         }
 
         /// <inheritdoc />
-        public Task<App> Update(string appId, Update.Request request, CancellationToken cancellationToken = default)
+        public Task<App> Update(string appId, UpdateAppRequest request, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(appId))
             {
@@ -158,7 +161,7 @@ namespace Sinch.Conversation.Apps
 
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/apps/{appId}{query}");
             _logger?.LogDebug("Updating an app for a {projectId} with {appId}", _projectId, appId);
-            return _http.Send<Update.Request, App>(uri, HttpMethod.Patch, request,
+            return _http.Send<UpdateAppRequest, App>(uri, HttpMethod.Patch, request,
                 cancellationToken: cancellationToken);
         }
 

--- a/src/Sinch/Conversation/Apps/Create/CreateAppRequest.cs
+++ b/src/Sinch/Conversation/Apps/Create/CreateAppRequest.cs
@@ -1,26 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Text;
-using System.Text.Json.Serialization;
 
-namespace Sinch.Conversation.Apps.Update
+namespace Sinch.Conversation.Apps.Create
 {
     /// <summary>
-    ///     Updates a particular app as specified by the App ID. Note that this is a PATCH operation,
-    ///     so any specified field values will replace existing values.
-    ///     Therefore, if you'd like to add additional configurations to an existing Conversation API app,
-    ///     ensure that you include existing values AND new values in the call. For example, if you'd like
-    ///     to add new channel_credentials, you can get your existing Conversation API app, extract the existing
-    ///     channel_credentials list, append your new configuration to that list, and include the updated channel_credentials
-    ///     list in this update call.
+    ///     The request sent to the API endpoint to create a new app.
     /// </summary>
-    public sealed class Request
+    public sealed class CreateAppRequest
     {
-        /// <summary>
-        ///     The set of field mask paths.
-        /// </summary>
-        [JsonIgnore]
-        public List<string> UpdateMaskPaths { get; set; }
-
         /// <summary>
         /// Gets or Sets ConversationMetadataReportView
         /// </summary>
@@ -29,7 +16,11 @@ namespace Sinch.Conversation.Apps.Update
         /// <summary>
         ///     An array of channel credentials. The order of the credentials defines the app channel priority.
         /// </summary>
+#if NET7_0_OR_GREATER
+        public required List<ConversationChannelCredential> ChannelCredentials { get; set; }
+#else
         public List<ConversationChannelCredential> ChannelCredentials { get; set; }
+#endif
 
 
         /// <summary>
@@ -74,7 +65,6 @@ namespace Sinch.Conversation.Apps.Update
         {
             var sb = new StringBuilder();
             sb.Append("class AppCreateRequest {\n");
-            sb.Append("  UpdateMaskPaths: ").Append(UpdateMaskPaths).Append("\n");
             sb.Append("  ChannelCredentials: ").Append(ChannelCredentials).Append("\n");
             sb.Append("  ConversationMetadataReportView: ").Append(ConversationMetadataReportView).Append("\n");
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");

--- a/src/Sinch/Conversation/Apps/Update/UpdateAppRequest.cs
+++ b/src/Sinch/Conversation/Apps/Update/UpdateAppRequest.cs
@@ -1,13 +1,26 @@
 ﻿using System.Collections.Generic;
 using System.Text;
+using System.Text.Json.Serialization;
 
-namespace Sinch.Conversation.Apps.Create
+namespace Sinch.Conversation.Apps.Update
 {
     /// <summary>
-    ///     The request sent to the API endpoint to create a new app.
+    ///     Updates a particular app as specified by the App ID. Note that this is a PATCH operation,
+    ///     so any specified field values will replace existing values.
+    ///     Therefore, if you'd like to add additional configurations to an existing Conversation API app,
+    ///     ensure that you include existing values AND new values in the call. For example, if you'd like
+    ///     to add new channel_credentials, you can get your existing Conversation API app, extract the existing
+    ///     channel_credentials list, append your new configuration to that list, and include the updated channel_credentials
+    ///     list in this update call.
     /// </summary>
-    public sealed class Request
+    public sealed class UpdateAppRequest
     {
+        /// <summary>
+        ///     The set of field mask paths.
+        /// </summary>
+        [JsonIgnore]
+        public List<string> UpdateMaskPaths { get; set; }
+
         /// <summary>
         /// Gets or Sets ConversationMetadataReportView
         /// </summary>
@@ -16,11 +29,7 @@ namespace Sinch.Conversation.Apps.Create
         /// <summary>
         ///     An array of channel credentials. The order of the credentials defines the app channel priority.
         /// </summary>
-#if NET7_0_OR_GREATER
-        public required List<ConversationChannelCredential> ChannelCredentials { get; set; }
-#else
         public List<ConversationChannelCredential> ChannelCredentials { get; set; }
-#endif
 
 
         /// <summary>
@@ -65,6 +74,7 @@ namespace Sinch.Conversation.Apps.Create
         {
             var sb = new StringBuilder();
             sb.Append("class AppCreateRequest {\n");
+            sb.Append("  UpdateMaskPaths: ").Append(UpdateMaskPaths).Append("\n");
             sb.Append("  ChannelCredentials: ").Append(ChannelCredentials).Append("\n");
             sb.Append("  ConversationMetadataReportView: ").Append(ConversationMetadataReportView).Append("\n");
             sb.Append("  DisplayName: ").Append(DisplayName).Append("\n");

--- a/src/Sinch/Conversation/Conversation.cs
+++ b/src/Sinch/Conversation/Conversation.cs
@@ -15,11 +15,11 @@ namespace Sinch.Conversation
     /// </summary>
     public interface ISinchConversation
     {
-        /// <inheritdoc cref="IMessages" />
-        IMessages Messages { get; }
+        /// <inheritdoc cref="ISinchConversationMessages" />
+        ISinchConversationMessages Messages { get; }
 
-        /// <inheritdoc cref="IApp" />
-        IApp App { get; }
+        /// <inheritdoc cref="ISinchConversationApp" />
+        ISinchConversationApp App { get; }
     }
 
     /// <inheritdoc />
@@ -33,9 +33,9 @@ namespace Sinch.Conversation
         }
 
         /// <inheritdoc />
-        public IMessages Messages { get; }
+        public ISinchConversationMessages Messages { get; }
 
         /// <inheritdoc />
-        public IApp App { get; }
+        public ISinchConversationApp App { get; }
     }
 }

--- a/src/Sinch/Conversation/Conversation.cs
+++ b/src/Sinch/Conversation/Conversation.cs
@@ -13,7 +13,7 @@ namespace Sinch.Conversation
     ///     The Conversation API endpoint uses built-in transcoding to give you the power of conversation across all
     ///     supported channels and, if required, full control over channel specific features.
     /// </summary>
-    public interface IConversation
+    public interface ISinchConversation
     {
         /// <inheritdoc cref="IMessages" />
         IMessages Messages { get; }
@@ -23,7 +23,7 @@ namespace Sinch.Conversation
     }
 
     /// <inheritdoc />
-    internal class Conversation : IConversation
+    internal class Conversation : ISinchConversation
     {
         internal Conversation(string projectId, Uri baseAddress, LoggerFactory loggerFactory, IHttp http)
         {

--- a/src/Sinch/Conversation/Messages/Identified.cs
+++ b/src/Sinch/Conversation/Messages/Identified.cs
@@ -3,7 +3,7 @@ using Sinch.Core;
 
 namespace Sinch.Conversation.Messages
 {
-    public class Identified : OneOf<Contact, Identified>, IRecipient
+    public class Identified : IRecipient
     {
         public IdentifiedBy IdentifiedBy { get; set; }
     }
@@ -16,7 +16,7 @@ namespace Sinch.Conversation.Messages
     public class ChannelIdentity
     {
         public string AppId { get; set; }
-        
+
         public string Identity { get; set; }
 
         public ConversationChannel Channel { get; set; }

--- a/src/Sinch/Conversation/Messages/List/ListMessagesRequest.cs
+++ b/src/Sinch/Conversation/Messages/List/ListMessagesRequest.cs
@@ -4,7 +4,7 @@ using Sinch.Core;
 
 namespace Sinch.Conversation.Messages.List
 {
-    public class Request
+    public class ListMessagesRequest
     {
         /// <summary>
         ///     Id of the conversation. Available only when messages_source is CONVERSATION_SOURCE.

--- a/src/Sinch/Conversation/Messages/List/ListMessagesResponse.cs
+++ b/src/Sinch/Conversation/Messages/List/ListMessagesResponse.cs
@@ -3,7 +3,7 @@ using Sinch.Conversation.Messages.Message;
 
 namespace Sinch.Conversation.Messages.List
 {
-    public class Response
+    public class ListMessagesResponse
     {
         /// <summary>
         ///     List of messages associated to the referenced conversation.

--- a/src/Sinch/Conversation/Messages/Send/SendMessageRequest.cs
+++ b/src/Sinch/Conversation/Messages/Send/SendMessageRequest.cs
@@ -8,7 +8,7 @@ namespace Sinch.Conversation.Messages.Send
     /// <summary>
     ///     This is the request body for sending a message. `app_id`, `recipient`, and `message` are all required fields.
     /// </summary>
-    public sealed class Request
+    public sealed class SendMessageRequest
     {
         /// <summary>
         ///     The ID of the app sending the message.

--- a/src/Sinch/Conversation/Messages/Send/SendMessageResponse.cs
+++ b/src/Sinch/Conversation/Messages/Send/SendMessageResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.Conversation.Messages.Send
 {
-    public class Response
+    public class SendMessageResponse
     {
         /// <summary>
         ///     Timestamp when the Conversation API accepted the message for delivery to the referenced contact.

--- a/src/Sinch/Core/Extensions.cs
+++ b/src/Sinch/Core/Extensions.cs
@@ -10,14 +10,14 @@ namespace Sinch.Core
         ///     Throws an exception if the IsSuccessStatusCode property for the HTTP response is false.
         /// </summary>
         /// <param name="httpResponseMessage">HttpResponseMessage to check for an error.</param>
-        /// <exception cref="ApiException">An exception which represents API error with additional info.</exception>
+        /// <exception cref="SinchApiException">An exception which represents API error with additional info.</exception>
         public static async Task EnsureSuccessApiStatusCode(this HttpResponseMessage httpResponseMessage)
         {
             if (httpResponseMessage.IsSuccessStatusCode) return;
 
             var apiError = await httpResponseMessage.TryGetJson<ApiErrorResponse>();
 
-            throw new ApiException(httpResponseMessage.StatusCode, httpResponseMessage.ReasonPhrase, null, apiError);
+            throw new SinchApiException(httpResponseMessage.StatusCode, httpResponseMessage.ReasonPhrase, null, apiError);
         }
 
         public static async Task<T> TryGetJson<T>(this HttpResponseMessage httpResponseMessage)

--- a/src/Sinch/Core/Http.cs
+++ b/src/Sinch/Core/Http.cs
@@ -51,9 +51,9 @@ namespace Sinch.Core
         private readonly HttpClient _httpClient;
         private readonly JsonSerializerOptions _jsonSerializerOptions;
         private readonly ILoggerAdapter<Http> _logger;
-        private readonly IAuth _auth;
+        private readonly ISinchAuth _auth;
 
-        public Http(IAuth auth, HttpClient httpClient, ILoggerAdapter<Http> logger,
+        public Http(ISinchAuth auth, HttpClient httpClient, ILoggerAdapter<Http> logger,
             JsonNamingPolicy jsonNamingPolicy)
         {
             _logger = logger;

--- a/src/Sinch/Core/OneOf.cs
+++ b/src/Sinch/Core/OneOf.cs
@@ -1,6 +1,0 @@
-﻿namespace Sinch.Core
-{
-    public interface OneOf<T0, T1>
-    {
-    }
-}

--- a/src/Sinch/Numbers/Active/List/ListActiveNumbersRequest.cs
+++ b/src/Sinch/Numbers/Active/List/ListActiveNumbersRequest.cs
@@ -4,7 +4,7 @@ using System.Net;
 
 namespace Sinch.Numbers.Active.List
 {
-    public sealed class Request
+    public sealed class ListActiveNumbersRequest
     {
         /// <summary>
         ///     Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. <br /><br />

--- a/src/Sinch/Numbers/Active/List/ListActiveNumbersResponse.cs
+++ b/src/Sinch/Numbers/Active/List/ListActiveNumbersResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.Numbers.Active.List
 {
-    public class Response
+    public class ListActiveNumbersResponse
     {
 #if NET7_0_OR_GREATER
         public required IEnumerable<ActiveNumber> ActiveNumbers { get; set; }

--- a/src/Sinch/Numbers/Active/Update/UpdateActiveNumberRequest.cs
+++ b/src/Sinch/Numbers/Active/Update/UpdateActiveNumberRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sinch.Numbers.Active.Update
 {
-    public sealed class Request
+    public sealed class UpdateActiveNumberRequest
     {
         /// <summary>
         ///     User supplied name for the phone number.

--- a/src/Sinch/Numbers/Available/List/ListAvailableNumbersRequest.cs
+++ b/src/Sinch/Numbers/Available/List/ListAvailableNumbersRequest.cs
@@ -4,7 +4,7 @@ using Sinch.Core;
 
 namespace Sinch.Numbers.Available.List
 {
-    public sealed class Request
+    public sealed class ListAvailableNumbersRequest
     {
         /// <summary>
         ///     Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number.

--- a/src/Sinch/Numbers/Available/List/ListAvailableNumbersResponse.cs
+++ b/src/Sinch/Numbers/Available/List/ListAvailableNumbersResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.Numbers.Available.List
 {
-    public sealed class Response
+    public sealed class ListAvailableNumbersResponse
     {
         public IEnumerable<AvailableNumber> AvailableNumbers { get; set; }
     }

--- a/src/Sinch/Numbers/Available/Rent/RentActiveNumberRequest.cs
+++ b/src/Sinch/Numbers/Available/Rent/RentActiveNumberRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Sinch.Numbers.Available.Rent
 {
-    public class Request
+    public class RentActiveNumberRequest
     {
         /// <summary>
         ///     The current SMS configuration for this number. <br /><br />

--- a/src/Sinch/Numbers/Available/RentAny/RentAnyNumberRequest.cs
+++ b/src/Sinch/Numbers/Available/RentAny/RentAnyNumberRequest.cs
@@ -5,7 +5,7 @@ namespace Sinch.Numbers.Available.RentAny
     /// <summary>
     ///     The request to search and rent a number that matches the criteria.
     /// </summary>
-    public sealed class Request
+    public sealed class RentAnyNumberRequest
     {
         public NumberPattern NumberPattern { get; set; }
 

--- a/src/Sinch/Numbers/Numbers.cs
+++ b/src/Sinch/Numbers/Numbers.cs
@@ -13,18 +13,18 @@ namespace Sinch.Numbers
         /// <summary>
         ///     You can use the Available Regions API to list all of the regions that have numbers assigned to a project.
         /// </summary>
-        public IRegions Regions { get; }
+        public ISinchNumbersRegions Regions { get; }
 
         /// <summary>
         ///     You can use the Available Number API to search for available numbers or activate an available number.
         /// </summary>
-        public IAvailable Available { get; }
+        public ISinchNumbersAvailable Available { get; }
 
         /// <summary>
         ///     You can use the Active Number API to manage numbers you own. Assign numbers to projects,
         ///     release numbers from projects, or list all numbers assigned to a project.
         /// </summary>
-        public IActive Active { get; }
+        public ISinchNumbersActive Active { get; }
     }
 
     public sealed class Numbers : ISinchNumbers
@@ -40,10 +40,10 @@ namespace Sinch.Numbers
                 loggerFactory?.Create<AvailableNumbers>(), http);
         }
 
-        public IRegions Regions { get; }
+        public ISinchNumbersRegions Regions { get; }
 
-        public IActive Active { get; }
+        public ISinchNumbersActive Active { get; }
 
-        public IAvailable Available { get; }
+        public ISinchNumbersAvailable Available { get; }
     }
 }

--- a/src/Sinch/Numbers/Numbers.cs
+++ b/src/Sinch/Numbers/Numbers.cs
@@ -8,7 +8,7 @@ namespace Sinch.Numbers
     ///     You can use the Active Number API to manage numbers you own. Assign numbers to projects, release numbers from
     ///     projects, or list all numbers assigned to a project.
     /// </summary>
-    public interface INumbers
+    public interface ISinchNumbers
     {
         /// <summary>
         ///     You can use the Available Regions API to list all of the regions that have numbers assigned to a project.
@@ -27,7 +27,7 @@ namespace Sinch.Numbers
         public IActive Active { get; }
     }
 
-    public sealed class Numbers : INumbers
+    public sealed class Numbers : ISinchNumbers
     {
         internal Numbers(string projectId, Uri baseAddress,
             LoggerFactory loggerFactory, IHttp http)

--- a/src/Sinch/Numbers/Regions.cs
+++ b/src/Sinch/Numbers/Regions.cs
@@ -10,7 +10,7 @@ using Sinch.Numbers.Regions;
 
 namespace Sinch.Numbers
 {
-    public interface IRegions
+    public interface ISinchNumbersRegions
     {
         /// <summary>
         ///     Lists all virtual numbers for a project.
@@ -25,7 +25,7 @@ namespace Sinch.Numbers
             CancellationToken cancellationToken = default);
     }
 
-    internal class AvailableRegions : IRegions
+    internal class AvailableRegions : ISinchNumbersRegions
     {
         private readonly Uri _baseAddress;
         private readonly IHttp _http;
@@ -41,6 +41,7 @@ namespace Sinch.Numbers
             _http = http;
         }
 
+        /// <inheritdoc />
         public async Task<IEnumerable<Region>> List(IEnumerable<Types> types,
             CancellationToken cancellationToken = default)
         {
@@ -57,7 +58,7 @@ namespace Sinch.Numbers
             }
 
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/availableRegions?{typesStr}");
-            var response = await _http.Send<Response>(uri, HttpMethod.Get, cancellationToken);
+            var response = await _http.Send<ListRegionsResponse>(uri, HttpMethod.Get, cancellationToken);
 
             return response.AvailableRegions;
         }

--- a/src/Sinch/Numbers/Regions/ListRegionsResponse.cs
+++ b/src/Sinch/Numbers/Regions/ListRegionsResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.Numbers.Regions
 {
-    internal sealed class Response
+    internal sealed class ListRegionsResponse
     {
 #if NET7_0_OR_GREATER
         public required IList<Region> AvailableRegions { get; set; }

--- a/src/Sinch/SMS/Batches/DryRun/DryRunRequest.cs
+++ b/src/Sinch/SMS/Batches/DryRun/DryRunRequest.cs
@@ -5,7 +5,7 @@ using Sinch.Core;
 
 namespace Sinch.SMS.Batches.DryRun
 {
-    public class Request
+    public class DryRunRequest
     {
         /// <summary>
         ///     Whether to include per recipient details in the response

--- a/src/Sinch/SMS/Batches/DryRun/DryRunResponse.cs
+++ b/src/Sinch/SMS/Batches/DryRun/DryRunResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.SMS.Batches.DryRun
 {
-    public class Response
+    public class DryRunResponse
     {
         /// <summary>
         ///     The number of recipients in the batch

--- a/src/Sinch/SMS/Batches/List/ListBatchesRequest.cs
+++ b/src/Sinch/SMS/Batches/List/ListBatchesRequest.cs
@@ -5,7 +5,7 @@ using Sinch.Core;
 
 namespace Sinch.SMS.Batches.List
 {
-    public sealed class Request
+    public sealed class ListBatchesRequest
     {
         /// <summary>
         ///     The page number starting from 0.

--- a/src/Sinch/SMS/Batches/List/ListBatchesResponse.cs
+++ b/src/Sinch/SMS/Batches/List/ListBatchesResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.SMS.Batches.List
 {
-    public class Response
+    public class ListBatchesResponse
     {
         /// <summary>
         ///     The requested page.

--- a/src/Sinch/SMS/Batches/Send/SendBatchRequest.cs
+++ b/src/Sinch/SMS/Batches/Send/SendBatchRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Sinch.SMS.Batches.Send
 {
-    public class Request
+    public class SendBatchRequest
     {
         /// <summary>
         ///     The message content. 2000 characters max

--- a/src/Sinch/SMS/Batches/Update/UpdateBatchRequest.cs
+++ b/src/Sinch/SMS/Batches/Update/UpdateBatchRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Sinch.SMS.Batches.Update
 {
-    public class Request
+    public class UpdateBatchRequest
     {
         /// <summary>
         ///     Sender number. Must be valid phone number, short code or alphanumeric.

--- a/src/Sinch/SMS/DeliveryReports/DeliveryReports.cs
+++ b/src/Sinch/SMS/DeliveryReports/DeliveryReports.cs
@@ -10,7 +10,7 @@ using Sinch.SMS.DeliveryReports.Get;
 
 namespace Sinch.SMS.DeliveryReports
 {
-    public interface IDeliveryReports
+    public interface ISinchSmsDeliveryReports
     {
         /// <summary>
         ///     Delivery reports can be retrieved even if no callback was requested.
@@ -53,7 +53,7 @@ namespace Sinch.SMS.DeliveryReports
     }
 
     /// <inheritdoc />
-    internal class DeliveryReports : IDeliveryReports
+    internal class DeliveryReports : ISinchSmsDeliveryReports
     {
         private readonly Uri _baseAddress;
         private readonly IHttp _http;

--- a/src/Sinch/SMS/DeliveryReports/DeliveryReports.cs
+++ b/src/Sinch/SMS/DeliveryReports/DeliveryReports.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Sinch.Core;
 using Sinch.Logger;
 using Sinch.SMS.DeliveryReports.Get;
+using Sinch.SMS.DeliveryReports.List;
 
 namespace Sinch.SMS.DeliveryReports
 {
@@ -21,7 +22,7 @@ namespace Sinch.SMS.DeliveryReports
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<Response> Get(Request request, CancellationToken cancellationToken = default);
+        Task<GetDeliveryReportResponse> Get(GetDeliveryReportRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     A recipient delivery report contains the message status for a single recipient phone number.
@@ -40,7 +41,7 @@ namespace Sinch.SMS.DeliveryReports
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<List.Response> List(List.Request request, CancellationToken cancellationToken = default);
+        Task<ListDeliveryReportsResponse> List(ListDeliveryReportsRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Get a list of finished delivery reports.<br /><br />
@@ -49,7 +50,7 @@ namespace Sinch.SMS.DeliveryReports
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>An async enumerable of <see cref="DeliveryReport"/></returns>
-        IAsyncEnumerable<DeliveryReport> ListAuto(List.Request request, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<DeliveryReport> ListAuto(ListDeliveryReportsRequest request, CancellationToken cancellationToken = default);
     }
 
     /// <inheritdoc />
@@ -68,15 +69,17 @@ namespace Sinch.SMS.DeliveryReports
             _http = http;
         }
 
-        public Task<Response> Get(Request request, CancellationToken cancellationToken = default)
+        /// <inheritdoc />
+        public Task<GetDeliveryReportResponse> Get(GetDeliveryReportRequest request, CancellationToken cancellationToken = default)
         {
             var uri = new Uri(_baseAddress,
                 $"xms/v1/{_projectId}/batches/{request.BatchId}/delivery_report?{request.GetQueryString()}");
             _logger?.LogDebug("Fetching delivery report for a batch with {id}", request.BatchId);
 
-            return _http.Send<Request, Response>(uri, HttpMethod.Get, null, cancellationToken)!;
+            return _http.Send<GetDeliveryReportRequest, GetDeliveryReportResponse>(uri, HttpMethod.Get, null, cancellationToken)!;
         }
 
+        /// <inheritdoc />
         public Task<DeliveryReport> GetForNumber(string batchId, string recipientMsisdn,
             CancellationToken cancellationToken = default)
         {
@@ -88,17 +91,19 @@ namespace Sinch.SMS.DeliveryReports
             return _http.Send<object, DeliveryReport>(uri, HttpMethod.Get, null, cancellationToken)!;
         }
 
-        public Task<List.Response> List(List.Request request, CancellationToken cancellationToken = default)
+        /// <inheritdoc />
+        public Task<ListDeliveryReportsResponse> List(ListDeliveryReportsRequest request, CancellationToken cancellationToken = default)
         {
             var uri = new Uri(_baseAddress,
                 $"xms/v1/{_projectId}/delivery_reports?{request.GetQueryString()}");
 
             _logger?.LogDebug("Listing delivery reports for {projectId}", _projectId);
 
-            return _http.Send<object, List.Response>(uri, HttpMethod.Get, null, cancellationToken);
+            return _http.Send<object, ListDeliveryReportsResponse>(uri, HttpMethod.Get, null, cancellationToken);
         }
 
-        public async IAsyncEnumerable<DeliveryReport> ListAuto(List.Request request,
+        /// <inheritdoc />
+        public async IAsyncEnumerable<DeliveryReport> ListAuto(ListDeliveryReportsRequest request,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             _logger?.LogDebug("Listing delivery reports for {projectId}", _projectId);
@@ -109,7 +114,7 @@ namespace Sinch.SMS.DeliveryReports
                     $"xms/v1/{_projectId}/delivery_reports?{request.GetQueryString()}");
 
 
-                var response = await _http.Send<List.Response>(uri, HttpMethod.Get, cancellationToken);
+                var response = await _http.Send<ListDeliveryReportsResponse>(uri, HttpMethod.Get, cancellationToken);
                 foreach (var report in response.DeliveryReports)
                 {
                     yield return report;

--- a/src/Sinch/SMS/DeliveryReports/Get/GetDeliveryReportRequest.cs
+++ b/src/Sinch/SMS/DeliveryReports/Get/GetDeliveryReportRequest.cs
@@ -4,7 +4,7 @@ using Sinch.Core;
 
 namespace Sinch.SMS.DeliveryReports.Get
 {
-    public sealed class Request
+    public sealed class GetDeliveryReportRequest
     {
         /// <summary>
         ///     The batch ID you received from sending a message.

--- a/src/Sinch/SMS/DeliveryReports/Get/GetDeliveryReportResponse.cs
+++ b/src/Sinch/SMS/DeliveryReports/Get/GetDeliveryReportResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.SMS.DeliveryReports.Get
 {
-    public sealed class Response
+    public sealed class GetDeliveryReportResponse
     {
         /// <summary>
         ///     The type of webhook for the delivery report.

--- a/src/Sinch/SMS/DeliveryReports/List/ListDeliveryReportsRequest.cs
+++ b/src/Sinch/SMS/DeliveryReports/List/ListDeliveryReportsRequest.cs
@@ -5,7 +5,7 @@ using Sinch.Core;
 
 namespace Sinch.SMS.DeliveryReports.List
 {
-    public sealed class Request
+    public sealed class ListDeliveryReportsRequest
     {
         public int Page { get; set; }
 

--- a/src/Sinch/SMS/DeliveryReports/List/ListDeliveryReportsResponse.cs
+++ b/src/Sinch/SMS/DeliveryReports/List/ListDeliveryReportsResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.SMS.DeliveryReports.List
 {
-    public sealed class Response
+    public sealed class ListDeliveryReportsResponse
     {
         /// <summary>
         ///     The total number of entries matching the given filters.

--- a/src/Sinch/SMS/Groups/Create/Request.c.cs
+++ b/src/Sinch/SMS/Groups/Create/Request.c.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.SMS.Groups.Create
 {
-    public sealed class Request
+    public sealed class CreateGroupRequest
     {
         /// <summary>
         ///     Name of the group

--- a/src/Sinch/SMS/Groups/Groups.cs
+++ b/src/Sinch/SMS/Groups/Groups.cs
@@ -13,7 +13,7 @@ using Request = Sinch.SMS.Groups.List.Request;
 
 namespace Sinch.SMS.Groups
 {
-    public interface IGroups
+    public interface ISinchSmsGroups
     {
         /// <summary>
         ///     With the list operation you can list all groups that you have created. This operation supports pagination.<br />
@@ -100,7 +100,7 @@ namespace Sinch.SMS.Groups
         Task<IEnumerable<string>> ListMembers(string groupId, CancellationToken cancellationToken = default);
     }
 
-    internal sealed class Groups : IGroups
+    internal sealed class Groups : ISinchSmsGroups
     {
         private readonly Uri _baseAddress;
         private readonly IHttp _http;

--- a/src/Sinch/SMS/Groups/List/ListGroupsResponse.cs
+++ b/src/Sinch/SMS/Groups/List/ListGroupsResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.SMS.Groups.List
 {
-    public class Response
+    public class ListGroupsResponse
     {
         /// <summary>
         ///     The requested page.

--- a/src/Sinch/SMS/Groups/List/Request.c.cs
+++ b/src/Sinch/SMS/Groups/List/Request.c.cs
@@ -3,7 +3,7 @@ using Sinch.Core;
 
 namespace Sinch.SMS.Groups.List
 {
-    public sealed class Request
+    public sealed class ListGroupsRequest
     {
         public int Page { get; set; }
 

--- a/src/Sinch/SMS/Groups/Replace/ReplaceGroupRequest.cs
+++ b/src/Sinch/SMS/Groups/Replace/ReplaceGroupRequest.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Sinch.SMS.Groups.Replace
 {
-    public sealed class Request
+    public sealed class ReplaceGroupRequest
     {
         /// <summary>
         ///     ID of a group that you are interested in getting.

--- a/src/Sinch/SMS/Groups/Update/UpdateGroupRequest.cs
+++ b/src/Sinch/SMS/Groups/Update/UpdateGroupRequest.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 
 namespace Sinch.SMS.Groups.Update
 {
-    public class Request : IGroupUpdateRequest
+    public class UpdateGroupRequest : IGroupUpdateRequest
     {
         /// <summary>
         ///     ID of a group that you are interested in getting.

--- a/src/Sinch/SMS/Inbounds/Inbounds.cs
+++ b/src/Sinch/SMS/Inbounds/Inbounds.cs
@@ -19,7 +19,7 @@ namespace Sinch.SMS.Inbounds
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<Response> List(Request request,
+        Task<ListInboundsResponse> List(ListInboundsRequest request,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace Sinch.SMS.Inbounds
         /// <param name="request"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        IAsyncEnumerable<Inbound> ListAuto(Request request, CancellationToken cancellationToken = default);
+        IAsyncEnumerable<Inbound> ListAuto(ListInboundsRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     This operation retrieves a specific inbound message with the provided inbound ID.
@@ -55,14 +55,14 @@ namespace Sinch.SMS.Inbounds
             _http = http;
         }
 
-        public Task<Response> List(Request request, CancellationToken cancellationToken = default)
+        public Task<ListInboundsResponse> List(ListInboundsRequest request, CancellationToken cancellationToken = default)
         {
             var uri = new Uri(_baseAddress, $"xms/v1/{_projectId}/inbounds?{request.GetQueryString()}");
             _logger?.LogDebug("Listing inbounds...");
-            return _http.Send<Response>(uri, HttpMethod.Get, cancellationToken);
+            return _http.Send<ListInboundsResponse>(uri, HttpMethod.Get, cancellationToken);
         }
 
-        public async IAsyncEnumerable<Inbound> ListAuto(Request request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        public async IAsyncEnumerable<Inbound> ListAuto(ListInboundsRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             _logger?.LogDebug("Auto listing inbounds...");
             bool isLastPage;
@@ -70,7 +70,7 @@ namespace Sinch.SMS.Inbounds
             {
                 var uri = new Uri(_baseAddress, $"xms/v1/{_projectId}/inbounds?{request.GetQueryString()}");
                 _logger?.LogDebug("Auto list {page}", request.Page);
-                var response = await _http.Send<Response>(uri, HttpMethod.Get, cancellationToken);
+                var response = await _http.Send<ListInboundsResponse>(uri, HttpMethod.Get, cancellationToken);
                 foreach (var inbound in response.Inbounds)
                 {
                     yield return inbound;

--- a/src/Sinch/SMS/Inbounds/Inbounds.cs
+++ b/src/Sinch/SMS/Inbounds/Inbounds.cs
@@ -10,7 +10,7 @@ using Sinch.SMS.Inbounds.List;
 
 namespace Sinch.SMS.Inbounds
 {
-    public interface IInbounds
+    public interface ISinchSmsInbounds
     {
         /// <summary>
         ///     With the list operation, you can list all inbound messages that you have received.
@@ -40,7 +40,7 @@ namespace Sinch.SMS.Inbounds
         Task<Inbound> Get(string inboundId, CancellationToken cancellationToken = default);
     }
 
-    public class Inbounds : IInbounds
+    public class Inbounds : ISinchSmsInbounds
     {
         private readonly Uri _baseAddress;
         private readonly IHttp _http;

--- a/src/Sinch/SMS/Inbounds/List/ListInboundsRequest.cs
+++ b/src/Sinch/SMS/Inbounds/List/ListInboundsRequest.cs
@@ -5,7 +5,7 @@ using Sinch.Core;
 
 namespace Sinch.SMS.Inbounds.List
 {
-    public sealed class Request
+    public sealed class ListInboundsRequest
     {
         /// <summary>
         ///     The page number starting from 0.

--- a/src/Sinch/SMS/Inbounds/List/ListInboundsResponse.cs
+++ b/src/Sinch/SMS/Inbounds/List/ListInboundsResponse.cs
@@ -2,7 +2,7 @@
 
 namespace Sinch.SMS.Inbounds.List
 {
-    public sealed class Response
+    public sealed class ListInboundsResponse
     {
         public int Page { get; set; }
 

--- a/src/Sinch/SMS/Sms.cs
+++ b/src/Sinch/SMS/Sms.cs
@@ -18,14 +18,14 @@ namespace Sinch.SMS
         ///     Batches are sets of SMS messages. You can send a single message or many.
         ///     Batches are queued and sent at the rate limit in first-in-first-out order.
         /// </summary>
-        IBatches Batches { get; }
+        ISinchSmsBatches Batches { get; }
 
         /// <summary>
         ///     Inbounds, or Mobile Originated (MO) messages, are incoming messages.
         ///     Inbound messages can be listed and retrieved like batch messages and
         ///     they can also be delivered by callback requests like delivery reports.
         /// </summary>
-        IInbounds Inbounds { get; }
+        ISinchSmsInbounds Inbounds { get; }
 
         /// <summary>
         ///     A group is a set of phone numbers
@@ -34,7 +34,7 @@ namespace Sinch.SMS
         ///     An phone number (MSISDN) can only occur once in a group
         ///     and any attempts to add a duplicate are ignored but not rejected.
         /// </summary>
-        IGroups Groups { get; }
+        ISinchSmsGroups Groups { get; }
 
         /// <summary>
         ///     uses message statuses and error codes in delivery reports,
@@ -46,7 +46,7 @@ namespace Sinch.SMS
         ///     </see>
         ///     or sent to a callback.
         /// </summary>
-        IDeliveryReports DeliveryReports { get; }
+        ISinchSmsDeliveryReports DeliveryReports { get; }
     }
 
     internal class Sms : ISinchSms
@@ -60,12 +60,12 @@ namespace Sinch.SMS
                 loggerFactory?.Create<DeliveryReports.DeliveryReports>(), http);
         }
 
-        public IBatches Batches { get; }
+        public ISinchSmsBatches Batches { get; }
 
-        public IInbounds Inbounds { get; }
+        public ISinchSmsInbounds Inbounds { get; }
 
-        public IGroups Groups { get; }
+        public ISinchSmsGroups Groups { get; }
 
-        public IDeliveryReports DeliveryReports { get; }
+        public ISinchSmsDeliveryReports DeliveryReports { get; }
     }
 }

--- a/src/Sinch/SMS/Sms.cs
+++ b/src/Sinch/SMS/Sms.cs
@@ -12,7 +12,7 @@ namespace Sinch.SMS
     ///     Send and receive SMS through a single connection for timely and cost-efficient communications using the Sinch SMS
     ///     API.
     /// </summary>
-    public interface ISms
+    public interface ISinchSms
     {
         /// <summary>
         ///     Batches are sets of SMS messages. You can send a single message or many.
@@ -49,7 +49,7 @@ namespace Sinch.SMS
         IDeliveryReports DeliveryReports { get; }
     }
 
-    internal class Sms : ISms
+    internal class Sms : ISinchSms
     {
         internal Sms(string projectId, Uri baseAddress, LoggerFactory loggerFactory, IHttp http)
         {

--- a/src/Sinch/SinchApiException.cs
+++ b/src/Sinch/SinchApiException.cs
@@ -11,9 +11,9 @@ namespace Sinch
     /// <summary>
     ///     Contains the information about failed request
     /// </summary>
-    public sealed class ApiException : HttpRequestException
+    public sealed class SinchApiException : HttpRequestException
     {
-        private ApiException(string message, Exception inner, HttpStatusCode statusCode) : base(message, inner,
+        private SinchApiException(string message, Exception inner, HttpStatusCode statusCode) : base(message, inner,
             statusCode)
         {
 #if NET6_0_OR_GREATER
@@ -21,7 +21,7 @@ namespace Sinch
 #endif
         }
 
-        internal ApiException(HttpStatusCode statusCode, string message, Exception inner, ApiErrorResponse authApiError)
+        internal SinchApiException(HttpStatusCode statusCode, string message, Exception inner, ApiErrorResponse authApiError)
             : this($"{message}:{authApiError?.Error?.Message ?? authApiError?.Text}", inner, statusCode)
         {
             // https://developers.sinch.com/docs/sms/api-reference/status-codes/#4xx---user-errors

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -11,7 +11,7 @@ using Sinch.Verification;
 
 namespace Sinch
 {
-    public interface ISinch
+    public interface ISinchClient
     {
         /// <summary>
         ///     An OAuth2.0 functionality for an SDK in case you want to fetch tokens.
@@ -19,7 +19,7 @@ namespace Sinch
         ///         Learn more.
         ///     </see>
         /// </summary>
-        public IAuth Auth { get; }
+        public ISinchAuth Auth { get; }
 
         /// <summary>
         ///     The Numbers API enables you to search for, view, and activate numbers.
@@ -38,7 +38,7 @@ namespace Sinch
         ///         Learn more.
         ///     </see>
         /// </summary>
-        public INumbers Numbers { get; }
+        public ISinchNumbers Numbers { get; }
 
         /// <summary>
         ///     Send and receive SMS through a single connection for timely and cost-efficient communications using
@@ -47,7 +47,7 @@ namespace Sinch
         ///         Learn more.
         ///     </see>
         /// </summary>
-        public ISms Sms { get; }
+        public ISinchSms Sms { get; }
 
         /// <summary>
         ///     Send and receive messages globally over SMS, RCS, WhatsApp, Viber Business,
@@ -56,7 +56,7 @@ namespace Sinch
         ///     across all supported channels and, if required, full control over channel specific features.<br/><br/>
         ///     <see href="https://developers.sinch.com/docs/conversation/api-reference/">Learn more.</see>
         /// </summary>
-        public IConversation Conversation { get; set; }
+        public ISinchConversation Conversation { get; set; }
 
         /// <summary>
         ///     Verify users with SMS, flash calls (missed calls), a regular call, or data verification.
@@ -85,12 +85,16 @@ namespace Sinch
         /// </summary>
         /// <param name="appKey"></param>
         /// <param name="appSecret"></param>
+        /// <param name="authStrategy">
+        ///     Choose which authentication to use.
+        ///     Defaults to Application Sign request and it's a recommended approach.
+        /// </param>
         /// <returns></returns>
         public ISinchVerificationClient Verification(string appKey, string appSecret,
             AuthStrategy authStrategy = AuthStrategy.ApplicationSign);
     }
 
-    public class SinchClient : ISinch
+    public class SinchClient : ISinchClient
     {
         private const string VerificationApiUrl = "https://verification.api.sinch.com/";
         private const string NumbersApiUrl = "https://numbers.api.sinch.com/";
@@ -137,7 +141,7 @@ namespace Sinch
             var logger = _loggerFactory?.Create<SinchClient>();
             logger?.LogInformation("Initializing SinchClient...");
 
-            IAuth auth =
+            ISinchAuth auth =
                 new OAuth(keyId, keySecret, optionsObj.HttpClient, _loggerFactory?.Create<OAuth>());
             var httpCamelCase = new Http(auth, optionsObj.HttpClient, _loggerFactory?.Create<Http>(),
                 JsonNamingPolicy.CamelCase);
@@ -189,17 +193,17 @@ namespace Sinch
         }
 
         /// <inheritdoc/>       
-        public INumbers Numbers { get; }
+        public ISinchNumbers Numbers { get; }
 
         /// <inheritdoc/>
-        public ISms Sms { get; }
+        public ISinchSms Sms { get; }
 
         /// <inheritdoc/>
-        public IConversation Conversation { get; set; }
+        public ISinchConversation Conversation { get; set; }
 
 
         /// <inheritdoc/>
-        public IAuth Auth { get; }
+        public ISinchAuth Auth { get; }
 
         /// <inheritdoc/>
         public ISinchVerificationClient Verification(string appKey, string appSecret,
@@ -215,7 +219,7 @@ namespace Sinch
                 throw new ArgumentNullException(nameof(appSecret), "The value should be present");
             }
 
-            IAuth auth;
+            ISinchAuth auth;
             if (authStrategy == AuthStrategy.ApplicationSign)
             {
                 auth = new ApplicationSignedAuth(appKey, appSecret);

--- a/tests/Sinch.Tests/AuthTests.cs
+++ b/tests/Sinch.Tests/AuthTests.cs
@@ -20,7 +20,7 @@ namespace Sinch.Tests
         private readonly ILoggerAdapter<OAuth> _logger = Substitute.For<ILoggerAdapter<OAuth>>();
         private readonly MockHttpMessageHandler _messageHandlerMock = new();
         private readonly MockedRequest _mockedRequest;
-        private readonly IAuth _auth;
+        private readonly ISinchAuth _auth;
 
         public AuthTests()
         {

--- a/tests/Sinch.Tests/AuthTests.cs
+++ b/tests/Sinch.Tests/AuthTests.cs
@@ -90,7 +90,7 @@ namespace Sinch.Tests
 
             Func<Task<string>> act = () => _auth.GetAuthToken();
 
-            await act.Should().ThrowAsync<AuthException>();
+            await act.Should().ThrowAsync<SinchAuthException>();
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace Sinch.Tests
 
             Func<Task<string>> act = () => _auth.GetAuthToken();
 
-            await act.Should().ThrowAsync<AuthException>().Where(x =>
+            await act.Should().ThrowAsync<SinchAuthException>().Where(x =>
                 x.Error == "invalid_request"
                 && x.ErrorVerbose == "long_description"
                 && x.ErrorDescription == "super_long_description"

--- a/tests/Sinch.Tests/Conversation/AppsTests.cs
+++ b/tests/Sinch.Tests/Conversation/AppsTests.cs
@@ -167,7 +167,7 @@ namespace Sinch.Tests.Conversation
             conversation_metadata_report_view = "FULL"
         };
 
-        private Request _createRequest = new Request
+        private CreateAppRequest _createRequest = new CreateAppRequest
         {
             DisplayName = "display_name",
             ChannelCredentials = new List<ConversationChannelCredential>()
@@ -377,7 +377,7 @@ namespace Sinch.Tests.Conversation
                 .WithQueryString("update_mask.paths", "b")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(_app));
 
-            var request = new Sinch.Conversation.Apps.Update.Request()
+            var request = new Sinch.Conversation.Apps.Update.UpdateAppRequest()
             {
                 DisplayName = "abc",
                 UpdateMaskPaths = new List<string>()

--- a/tests/Sinch.Tests/Conversation/ConversationTestBase.cs
+++ b/tests/Sinch.Tests/Conversation/ConversationTestBase.cs
@@ -5,7 +5,7 @@ namespace Sinch.Tests.Conversation
 {
     public class ConversationTestBase : TestBase
     {
-        internal readonly IConversation Conversation;
+        internal readonly ISinchConversation Conversation;
 
         protected ConversationTestBase()
         {

--- a/tests/Sinch.Tests/Conversation/MessagesTests.cs
+++ b/tests/Sinch.Tests/Conversation/MessagesTests.cs
@@ -113,7 +113,7 @@ namespace Sinch.Tests.Conversation
                 }));
 
             var dateTime = new DateTime(2022, 7, 12);
-            var response = await Conversation.Messages.List(new Request
+            var response = await Conversation.Messages.List(new ListMessagesRequest
             {
                 ConversationId = conversationId,
                 ContactId = contactId,

--- a/tests/Sinch.Tests/Conversation/MessagesTests.cs
+++ b/tests/Sinch.Tests/Conversation/MessagesTests.cs
@@ -181,7 +181,7 @@ namespace Sinch.Tests.Conversation
                 }));
 
             Func<Task> request = () => Conversation.Messages.Delete(messageId, MessageSource.ConversationSource);
-            await request.Should().ThrowAsync<ApiException>().WithMessage("Bad Request:Invalid argument")
+            await request.Should().ThrowAsync<SinchApiException>().WithMessage("Bad Request:Invalid argument")
                 .Where(x => x.DetailedMessage == "Invalid argument");
         }
 

--- a/tests/Sinch.Tests/Conversation/SendMessageTests.cs
+++ b/tests/Sinch.Tests/Conversation/SendMessageTests.cs
@@ -20,7 +20,7 @@ namespace Sinch.Tests.Conversation
     {
         private readonly dynamic _baseMessageExpected = new ExpandoObject();
 
-        private readonly Request _baseRequest = new Request
+        private readonly SendMessageRequest _baseRequest = new SendMessageRequest
         {
             AppId = "123",
             Message = new AppMessage()

--- a/tests/Sinch.Tests/Core/HttpTests.cs
+++ b/tests/Sinch.Tests/Core/HttpTests.cs
@@ -69,7 +69,7 @@ namespace Sinch.Tests.Core
 
             Func<Task<object>> response = () => http.Send<object>(uri, HttpMethod.Get);
 
-            var ex = await response.Should().ThrowAsync<ApiException>();
+            var ex = await response.Should().ThrowAsync<SinchApiException>();
             ex.Where(x => x.StatusCode == HttpStatusCode.Unauthorized);
             _httpMessageHandlerMock.VerifyNoOutstandingExpectation();
         }
@@ -93,7 +93,7 @@ namespace Sinch.Tests.Core
 
             Func<Task<object>> response = () => http.Send<object>(uri, HttpMethod.Get);
 
-            var ex = await response.Should().ThrowAsync<ApiException>();
+            var ex = await response.Should().ThrowAsync<SinchApiException>();
             ex.Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
             _httpMessageHandlerMock.VerifyNoOutstandingExpectation();
         }

--- a/tests/Sinch.Tests/Core/HttpTests.cs
+++ b/tests/Sinch.Tests/Core/HttpTests.cs
@@ -14,12 +14,12 @@ namespace Sinch.Tests.Core
 {
     public class HttpTests
     {
-        private readonly IAuth _tokenManagerMock;
+        private readonly ISinchAuth _tokenManagerMock;
         private readonly MockHttpMessageHandler _httpMessageHandlerMock;
 
         public HttpTests()
         {
-            _tokenManagerMock = Substitute.For<IAuth>();
+            _tokenManagerMock = Substitute.For<ISinchAuth>();
             _tokenManagerMock.Scheme.Returns("Bearer");
             _httpMessageHandlerMock = new MockHttpMessageHandler();
         }

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -47,7 +47,7 @@ namespace Sinch.Tests.Numbers
                     totalSize = 5
                 }));
 
-            var response = await Numbers.Active.List(new Request
+            var response = await Numbers.Active.List(new ListActiveNumbersRequest
             {
                 RegionCode = "US",
                 Type = Types.Mobile,
@@ -86,7 +86,7 @@ namespace Sinch.Tests.Numbers
                     totalSize = 5
                 }));
             
-            var request = new Request
+            var request = new ListActiveNumbersRequest
             {
                 RegionCode = "US",
                 Type = Types.Local,
@@ -130,7 +130,7 @@ namespace Sinch.Tests.Numbers
                 .Respond(HttpStatusCode.OK, JsonContent.Create(TestData.ActiveNumber));
 
 
-            var response = await Numbers.Active.Update("+12025550134", new Sinch.Numbers.Active.Update.Request
+            var response = await Numbers.Active.Update("+12025550134", new Sinch.Numbers.Active.Update.UpdateActiveNumberRequest
             {
                 DisplayName = "Name",
                 SmsConfiguration = new SmsConfiguration
@@ -184,7 +184,7 @@ namespace Sinch.Tests.Numbers
                 }));
 
 
-            var res = Numbers.Active.ListAuto(new Request
+            var res = Numbers.Active.ListAuto(new ListActiveNumbersRequest
             {
                 RegionCode = "US",
                 Type = Types.Mobile,

--- a/tests/Sinch.Tests/Numbers/AvailableNumbersTests.cs
+++ b/tests/Sinch.Tests/Numbers/AvailableNumbersTests.cs
@@ -26,7 +26,7 @@ namespace Sinch.Tests.Numbers
                 .WithPartialContent("service_plan")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(TestData.ActiveNumber));
 
-            var request = new Request
+            var request = new RentActiveNumberRequest
             {
                 SmsConfiguration = new SmsConfiguration
                 {
@@ -54,7 +54,7 @@ namespace Sinch.Tests.Numbers
                 .WithPartialContent("1208")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(TestData.ActiveNumber));
 
-            var request = new Sinch.Numbers.Available.RentAny.Request
+            var request = new Sinch.Numbers.Available.RentAny.RentAnyNumberRequest
             {
                 RegionCode = "US",
                 NumberPattern = new NumberPattern
@@ -93,7 +93,7 @@ namespace Sinch.Tests.Numbers
                 }));
 
             var response = await Numbers.Available.List(
-                new Sinch.Numbers.Available.List.Request
+                new Sinch.Numbers.Available.List.ListAvailableNumbersRequest
                 {
                     RegionCode = "US",
                     Type = Types.Mobile,

--- a/tests/Sinch.Tests/Numbers/AvailableNumbersTests.cs
+++ b/tests/Sinch.Tests/Numbers/AvailableNumbersTests.cs
@@ -154,7 +154,7 @@ namespace Sinch.Tests.Numbers
 
             Func<Task<AvailableNumber>> response = () => Numbers.Available.CheckAvailability("+12025550");
 
-            var exception = await response.Should().ThrowAsync<ApiException>();
+            var exception = await response.Should().ThrowAsync<SinchApiException>();
 #if NET6_0_OR_GREATER
             var node = exception.And.Details!.First();
             node["type"]!.GetValue<string>().Should().Be("ResourceInfo");

--- a/tests/Sinch.Tests/Numbers/NumberTestBase.cs
+++ b/tests/Sinch.Tests/Numbers/NumberTestBase.cs
@@ -5,7 +5,7 @@ namespace Sinch.Tests.Numbers
 {
     public class NumberTestBase : TestBase
     {
-        internal readonly INumbers Numbers;
+        internal readonly ISinchNumbers Numbers;
 
         protected NumberTestBase()
         {

--- a/tests/Sinch.Tests/SinchClientTests.cs
+++ b/tests/Sinch.Tests/SinchClientTests.cs
@@ -27,21 +27,21 @@ namespace Sinch.Tests
         [Fact]
         public void ThrowNullKeyId()
         {
-            Func<ISinch> initAction = () => new Sinch.SinchClient(null, "secret", "project");
+            Func<ISinchClient> initAction = () => new Sinch.SinchClient(null, "secret", "project");
             initAction.Should().Throw<ArgumentNullException>("Should have a value");
         }
 
         [Fact]
         public void ThrowNullKeySecret()
         {
-            Func<ISinch> initAction = () => new Sinch.SinchClient("secret", null, "project");
+            Func<ISinchClient> initAction = () => new Sinch.SinchClient("secret", null, "project");
             initAction.Should().Throw<ArgumentNullException>("Should have a value");
         }
 
         [Fact]
         public void ThrowNullProjectId()
         {
-            Func<ISinch> initAction = () => new Sinch.SinchClient("id", "secret", null);
+            Func<ISinchClient> initAction = () => new Sinch.SinchClient("id", "secret", null);
             initAction.Should().Throw<ArgumentNullException>("Should have a value");
         }
     }

--- a/tests/Sinch.Tests/Sms/BatchesTests.cs
+++ b/tests/Sinch.Tests/Sms/BatchesTests.cs
@@ -56,7 +56,7 @@ namespace Sinch.Tests.Sms
                 .WithPartialContent("irythil")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(Batch));
 
-            var request = new Request
+            var request = new SendBatchRequest
             {
                 Body = "Hi ${name}! How are you?",
                 DeliveryReport = DeliveryReport.Full,
@@ -120,7 +120,7 @@ namespace Sinch.Tests.Sms
                     }
                 }));
 
-            var request = new SMS.Batches.List.Request
+            var request = new SMS.Batches.List.ListBatchesRequest
             {
                 PageSize = 11,
                 ClientReference = "havel",
@@ -157,7 +157,7 @@ namespace Sinch.Tests.Sms
                     }
                 }));
 
-            var response = await Sms.Batches.DryRun(new SMS.Batches.DryRun.Request
+            var response = await Sms.Batches.DryRun(new SMS.Batches.DryRun.DryRunRequest
             {
                 PerRecipient = false,
                 NumberOfRecipients = 144,
@@ -214,7 +214,7 @@ namespace Sinch.Tests.Sms
                 .WithPartialContent("31231323")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(Batch));
 
-            var response = await Sms.Batches.Update("01FC66621XXXXX119Z8PMV1QPQ", new SMS.Batches.Update.Request
+            var response = await Sms.Batches.Update("01FC66621XXXXX119Z8PMV1QPQ", new SMS.Batches.Update.UpdateBatchRequest
             {
                 Body = null,
                 From = "31231323",
@@ -334,7 +334,7 @@ namespace Sinch.Tests.Sms
                         Batch
                     }
                 }));
-            var request = new SMS.Batches.List.Request();
+            var request = new SMS.Batches.List.ListBatchesRequest();
             var response = Sms.Batches.ListAuto(request);
             await foreach (var batch in response)
             {

--- a/tests/Sinch.Tests/Sms/DeliveryReportsTests.cs
+++ b/tests/Sinch.Tests/Sms/DeliveryReportsTests.cs
@@ -66,7 +66,7 @@ namespace Sinch.Tests.Sms
                     }
                 }));
 
-            var response = await Sms.DeliveryReports.Get(new Request
+            var response = await Sms.DeliveryReports.Get(new GetDeliveryReportRequest
             {
                 BatchId = batchId,
                 DeliveryReportType = DeliveryReportVerbosityType.Full,
@@ -146,7 +146,7 @@ namespace Sinch.Tests.Sms
                     }
                 }));
 
-            var response = await Sms.DeliveryReports.List(new SMS.DeliveryReports.List.Request
+            var response = await Sms.DeliveryReports.List(new SMS.DeliveryReports.List.ListDeliveryReportsRequest
             {
                 Page = 1,
                 PageSize = 30,
@@ -236,7 +236,7 @@ namespace Sinch.Tests.Sms
                     }
                 }));
             
-            var response = Sms.DeliveryReports.ListAuto(new SMS.DeliveryReports.List.Request
+            var response = Sms.DeliveryReports.ListAuto(new SMS.DeliveryReports.List.ListDeliveryReportsRequest
             {
                 Page = 0,
             });

--- a/tests/Sinch.Tests/Sms/GroupTests.cs
+++ b/tests/Sinch.Tests/Sms/GroupTests.cs
@@ -59,7 +59,7 @@ namespace Sinch.Tests.Sms
                     groups = new[] { _group, _group }
                 }));
 
-            var response = await Sms.Groups.List(new Request
+            var response = await Sms.Groups.List(new ListGroupsRequest
             {
                 Page = 1,
                 PageSize = 2
@@ -104,7 +104,7 @@ namespace Sinch.Tests.Sms
                     count = 3,
                     groups = new[] { _group, _group }
                 }));
-            var groups = Sms.Groups.ListAuto(new Request());
+            var groups = Sms.Groups.ListAuto(new ListGroupsRequest());
             var list = new List<Group>();
             await foreach (var group in groups)
             {
@@ -127,7 +127,7 @@ namespace Sinch.Tests.Sms
                 .WithPartialContent("child_groups")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(_group));
 
-            var response = await Sms.Groups.Create(new SMS.Groups.Create.Request
+            var response = await Sms.Groups.Create(new SMS.Groups.Create.CreateGroupRequest
             {
                 Name = "name_g",
                 Members = new List<string>() { "1", "2" },
@@ -178,7 +178,7 @@ namespace Sinch.Tests.Sms
                 })
                 .Respond(HttpStatusCode.OK, JsonContent.Create(_group));
 
-            var response = await Sms.Groups.Update(new SMS.Groups.Update.Request
+            var response = await Sms.Groups.Update(new SMS.Groups.Update.UpdateGroupRequest
             {
                 GroupId = "g1",
                 Name = "name_g",
@@ -212,7 +212,7 @@ namespace Sinch.Tests.Sms
                 .WithPartialContent("\"name\":null")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(_group));
 
-            var request = new SMS.Groups.Update.Request
+            var request = new SMS.Groups.Update.UpdateGroupRequest
             {
                 GroupId = "g1",
                 Name = null,
@@ -247,7 +247,7 @@ namespace Sinch.Tests.Sms
                 .WithPartialContent("\"name\":\"\"")
                 .Respond(HttpStatusCode.OK, JsonContent.Create(_group));
 
-            var request = new SMS.Groups.Update.Request
+            var request = new SMS.Groups.Update.UpdateGroupRequest
             {
                 GroupId = "g1",
                 Name = string.Empty,
@@ -283,7 +283,7 @@ namespace Sinch.Tests.Sms
                 .With(x => !x.Content!.ReadAsStringAsync().Result.Contains("group_id"))
                 .Respond(HttpStatusCode.OK, JsonContent.Create(_group));
 
-            var request = new SMS.Groups.Replace.Request
+            var request = new SMS.Groups.Replace.ReplaceGroupRequest
             {
                 GroupId = "g1",
                 Members = new List<string> { "123", "456" },

--- a/tests/Sinch.Tests/Sms/InboundsTests.cs
+++ b/tests/Sinch.Tests/Sms/InboundsTests.cs
@@ -72,7 +72,7 @@ namespace Sinch.Tests.Sms
                     }
                 }));
             var date = new DateTime(2019, 8, 24, 14, 15, 22, 542, DateTimeKind.Utc);
-            var request = new Request
+            var request = new ListInboundsRequest
             {
                 Page = 3,
                 PageSize = 0,
@@ -134,7 +134,7 @@ namespace Sinch.Tests.Sms
                         Inbound()
                     }
                 }));
-            var request = new Request
+            var request = new ListInboundsRequest
             {
                 Page = 0
             };

--- a/tests/Sinch.Tests/Sms/SmsTestBase.cs
+++ b/tests/Sinch.Tests/Sms/SmsTestBase.cs
@@ -5,7 +5,7 @@ namespace Sinch.Tests.Sms
 {
     public class SmsTestBase : TestBase
     {
-        internal readonly ISms Sms;
+        internal readonly ISinchSms Sms;
 
         protected SmsTestBase()
         {

--- a/tests/Sinch.Tests/TestBase.cs
+++ b/tests/Sinch.Tests/TestBase.cs
@@ -11,7 +11,7 @@ namespace Sinch.Tests
     {
         protected const string ProjectId = "MOCK_PROJECT_ID";
         protected const string Token = "to-ke-n";
-        private readonly IAuth _tokenManager = Substitute.For<IAuth>();
+        private readonly ISinchAuth _tokenManager = Substitute.For<ISinchAuth>();
         internal readonly Http HttpCamelCase;
         protected readonly MockHttpMessageHandler HttpMessageHandlerMock = new();
         internal readonly Http HttpSnakeCase;

--- a/tests/Sinch.Tests/e2e/NumbersTests.cs
+++ b/tests/Sinch.Tests/e2e/NumbersTests.cs
@@ -25,7 +25,7 @@ namespace Sinch.Tests.e2e
         [Fact]
         public async Task Rent()
         {
-            var response = await SinchClientMockStudio.Numbers.Available.Rent("+447520652221", new Request()
+            var response = await SinchClientMockStudio.Numbers.Available.Rent("+447520652221", new RentActiveNumberRequest()
             {
                 SmsConfiguration = null,
                 VoiceConfiguration = null,
@@ -37,7 +37,7 @@ namespace Sinch.Tests.e2e
         [Fact]
         public async Task ListAvailableWithPattern()
         {
-            var response = await SinchClientMockStudio.Numbers.Available.List(new Sinch.Numbers.Available.List.Request
+            var response = await SinchClientMockStudio.Numbers.Available.List(new Sinch.Numbers.Available.List.ListAvailableNumbersRequest
             {
                 RegionCode = "US",
                 Type = Types.Local,
@@ -53,7 +53,7 @@ namespace Sinch.Tests.e2e
         [Fact]
         public async Task ListAvailableWithCapabilities()
         {
-            var response = await SinchClientMockStudio.Numbers.Available.List(new Sinch.Numbers.Available.List.Request
+            var response = await SinchClientMockStudio.Numbers.Available.List(new Sinch.Numbers.Available.List.ListAvailableNumbersRequest
             {
                 RegionCode = "US",
                 Type = Types.Local,
@@ -68,7 +68,7 @@ namespace Sinch.Tests.e2e
         [Fact]
         public async Task ListActiveWithPageSize()
         {
-            var response = await SinchClientMockStudio.Numbers.Active.List(new Sinch.Numbers.Active.List.Request
+            var response = await SinchClientMockStudio.Numbers.Active.List(new Sinch.Numbers.Active.List.ListActiveNumbersRequest
             {
                 RegionCode = "GB",
                 Type = Types.Mobile,
@@ -81,7 +81,7 @@ namespace Sinch.Tests.e2e
         [Fact]
         public async Task ListActiveWithPageToken()
         {
-            var response = await SinchClientMockStudio.Numbers.Active.List(new Sinch.Numbers.Active.List.Request
+            var response = await SinchClientMockStudio.Numbers.Active.List(new Sinch.Numbers.Active.List.ListActiveNumbersRequest
             {
                 RegionCode = "GB",
                 Type = Types.Mobile,

--- a/tests/Sinch.Tests/e2e/Sms/DeliveryReportsTests.cs
+++ b/tests/Sinch.Tests/e2e/Sms/DeliveryReportsTests.cs
@@ -13,7 +13,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task Get()
         {
-            var response = await SinchClientMockStudio.Sms.DeliveryReports.Get(new Request
+            var response = await SinchClientMockStudio.Sms.DeliveryReports.Get(new GetDeliveryReportRequest
             {
                 BatchId = "01GRY6XP44CBK211XY3HFG09KR",
                 DeliveryReportType = DeliveryReportVerbosityType.Summary,
@@ -35,7 +35,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task List()
         {
-            var response = await SinchClientMockStudio.Sms.DeliveryReports.List(new SMS.DeliveryReports.List.Request()
+            var response = await SinchClientMockStudio.Sms.DeliveryReports.List(new SMS.DeliveryReports.List.ListDeliveryReportsRequest()
             {
                 
                 Page = 0,

--- a/tests/Sinch.Tests/e2e/Sms/GroupTests.cs
+++ b/tests/Sinch.Tests/e2e/Sms/GroupTests.cs
@@ -13,7 +13,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task Create()
         {
-            var response = await SinchClientMockStudio.Sms.Groups.Create(new Request
+            var response = await SinchClientMockStudio.Sms.Groups.Create(new CreateGroupRequest
             {
                 Name = "KillerRabbit",
                 Members = new List<string>()
@@ -35,7 +35,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task Update()
         {
-            var response = await SinchClientMockStudio.Sms.Groups.Update(new SMS.Groups.Update.Request
+            var response = await SinchClientMockStudio.Sms.Groups.Update(new SMS.Groups.Update.UpdateGroupRequest
             {
                 GroupId = "01GJFY2CEJQ0Y20704G8G506N9",
                 Name = "KillerRabbit222",
@@ -46,7 +46,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task Replace()
         {
-            var response = await SinchClientMockStudio.Sms.Groups.Replace(new SMS.Groups.Replace.Request
+            var response = await SinchClientMockStudio.Sms.Groups.Replace(new SMS.Groups.Replace.ReplaceGroupRequest
             {
                 GroupId = "01GJFY2CEJQ0Y20704G8G506N9",
                 Members = new List<string>()
@@ -74,7 +74,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task CreateWithChild()
         {
-            var response = await SinchClientMockStudio.Sms.Groups.Create(new Request()
+            var response = await SinchClientMockStudio.Sms.Groups.Create(new CreateGroupRequest()
             {
                 Name = "WithChildGroups",
                 Members = new List<string>()
@@ -92,7 +92,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task List()
         {
-            var response = await SinchClientMockStudio.Sms.Groups.List(new SMS.Groups.List.Request
+            var response = await SinchClientMockStudio.Sms.Groups.List(new SMS.Groups.List.ListGroupsRequest
             {
                 Page = 2,
             });

--- a/tests/Sinch.Tests/e2e/Sms/InboundsTests.cs
+++ b/tests/Sinch.Tests/e2e/Sms/InboundsTests.cs
@@ -10,7 +10,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task List()
         {
-            var response = await SinchClientMockStudio.Sms.Inbounds.List(new Request
+            var response = await SinchClientMockStudio.Sms.Inbounds.List(new ListInboundsRequest
             {
                 Page = 0,
             });

--- a/tests/Sinch.Tests/e2e/Sms/SmsTests.cs
+++ b/tests/Sinch.Tests/e2e/Sms/SmsTests.cs
@@ -15,7 +15,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task SendBatch()
         {
-            var response = await SinchClientMockStudio.Sms.Batches.Send(new Request
+            var response = await SinchClientMockStudio.Sms.Batches.Send(new SendBatchRequest
             {
                 Body = "Asynchronous Spanish Inquisition",
                 DeliveryReport = DeliveryReport.Summary,
@@ -29,7 +29,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task DryRun()
         {
-            var response = await SinchClientMockStudio.Sms.Batches.DryRun(new SMS.Batches.DryRun.Request
+            var response = await SinchClientMockStudio.Sms.Batches.DryRun(new SMS.Batches.DryRun.DryRunRequest
             {
                 To = new List<string>() { "+48 737532793" },
                 Body = "Spanish Inquisition",
@@ -45,7 +45,7 @@ namespace Sinch.Tests.e2e.Sms
         [Fact]
         public async Task ListBatches()
         {
-            var response = await SinchClientMockStudio.Sms.Batches.List(new SMS.Batches.List.Request
+            var response = await SinchClientMockStudio.Sms.Batches.List(new SMS.Batches.List.ListBatchesRequest
             {
                 Page = 0,
             });
@@ -63,7 +63,7 @@ namespace Sinch.Tests.e2e.Sms
         public async Task UpdateBatch()
         {
             var response = await SinchClientMockStudio.Sms.Batches.Update("01GK6ZMBRR3MQA0S2HA3K81EJJ",
-                new SMS.Batches.Update.Request()
+                new SMS.Batches.Update.UpdateBatchRequest()
                 {
                     Body = "Update Batch Test After Update"
                 });

--- a/tests/Sinch.Tests/e2e/TestBase.cs
+++ b/tests/Sinch.Tests/e2e/TestBase.cs
@@ -7,10 +7,10 @@ namespace Sinch.Tests.e2e
     {
         private const string ProjectId = "e15b2651-daac-4ccb-92e8-e3066d1d033b";
 
-        protected readonly ISinch SinchClientMockStudio;
+        protected readonly ISinchClient SinchClientMockStudio;
 
         // MockStudio should be removed and all contract testing should go to mock server version
-        protected readonly ISinch SinchClientMockServer;
+        protected readonly ISinchClient SinchClientMockServer;
 
         protected TestBase()
         {


### PR DESCRIPTION
Experiment with short names wasn't working out. 
The PR will be big, but it's only renaming of the types.
Bringing default microsoft convention for verbose class names.
Also, facade interfaces will have `Sinch` suffix to avoid any name clashing for those who will be mocking/reusing them

After this change I don't expect any great renaming in types