### PR TITLE
Feat/add sinch header

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
       
       # --include-symbols?
       - name: Pack
-        run: dotnet pack --configuration Release src/Sinch -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} --no-restore
+        run: dotnet pack --configuration Release src/Sinch -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -p:Version=${{ steps.gitversion.outputs.semVer }} --no-restore
 
       - name: Archive nuget packages
         uses: actions/upload-artifact@v3

--- a/tests/Sinch.Tests/Core/HttpTests.cs
+++ b/tests/Sinch.Tests/Core/HttpTests.cs
@@ -145,12 +145,13 @@ namespace Sinch.Tests.Core
 
             _httpMessageHandlerMock.Expect(HttpMethod.Get, uri.ToString())
                 .WithHeaders("Authorization", "Bearer first_token")
-                // somehow the matchers split header on whitespaces and check it by parts
-                // so,  .WithHeaders("User-Agent", $"sinch-sdk/{sdkVersion} (csharp/{RuntimeInformation.FrameworkDescription};;)")
-                // not working
-                .WithHeaders("User-Agent",
-                    $"sinch-sdk/{sdkVersion}")
-                .WithHeaders("User-Agent", $"(csharp/{RuntimeInformation.FrameworkDescription};;)")
+                // net framework splits header value at whitespace and returns list of values
+                // so we check for exact sequence of header value
+                .WithHeaderExact("User-Agent", new[]
+                {
+                    $"sinch-sdk/{sdkVersion}",
+                    $"(csharp/{RuntimeInformation.FrameworkDescription};;)"
+                })
                 .Respond(HttpStatusCode.OK);
 
             var httpClient = new HttpClient(_httpMessageHandlerMock);

--- a/tests/Sinch.Tests/Extensions.cs
+++ b/tests/Sinch.Tests/Extensions.cs
@@ -1,4 +1,5 @@
-﻿using RichardSzalay.MockHttp;
+﻿using System.Collections.Generic;
+using RichardSzalay.MockHttp;
 
 namespace Sinch.Tests
 {
@@ -20,6 +21,14 @@ namespace Sinch.Tests
         public static MockedRequest WithJson(this MockedRequest source, object obj)
         {
             source.With(new JsonMatcher(obj));
+
+            return source;
+        }
+
+        public static MockedRequest WithHeaderExact(this MockedRequest source, string headerKey,
+            IEnumerable<string> headerValues)
+        {
+            source.With(new HeaderExactMatcher(headerKey, headerValues));
 
             return source;
         }

--- a/tests/Sinch.Tests/HeaderExactMatcher.cs
+++ b/tests/Sinch.Tests/HeaderExactMatcher.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using RichardSzalay.MockHttp;
+
+namespace Sinch.Tests
+{
+    /// <summary>
+    ///     Matches for a specific header with an exact header value.
+    /// </summary>
+    public class HeaderExactMatcher : IMockedRequestMatcher
+    {
+        private readonly string _headerKey;
+        private readonly IEnumerable<string> _headerValues;
+
+        public HeaderExactMatcher(string headerKey, IEnumerable<string> headerValues)
+        {
+            _headerKey = headerKey;
+            _headerValues = headerValues;
+        }
+
+        public bool Matches(HttpRequestMessage message)
+        {
+            return message.Headers.GetValues(_headerKey).SequenceEqual(_headerValues);
+        }
+    }
+}


### PR DESCRIPTION
Add sensing of User-Agent
Format will be: sinch-sdk/{sdk_version} ({language}/{language_version}; {implementation_type}; {auxiliary_flag})

Where:

    sdk_version: Package version
    language: csharp
    language_version: net runtime version
    implementation_type: skipped, no specifics 
    auxiliary_flag: skipped

Example of generated header: User-Agent: sinch-sdk/0.1.13-alpha (csharp/NET 7.0.1;;)
