### PR TITLE
Voice: add callbacks

### DIFF
--- a/src/Sinch/Voice/Calls/Actions/CallHeader.cs
+++ b/src/Sinch/Voice/Calls/Actions/CallHeader.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Actions
 {
@@ -12,12 +13,14 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     The call header key of the key value pair.
         /// </summary>
+        [JsonPropertyName("key")]
         public string Key { get; set; }
 
 
         /// <summary>
         ///     The call header value of the key value pair.
         /// </summary>
+        [JsonPropertyName("value")]
         public string Value { get; set; }
 
 

--- a/src/Sinch/Voice/Calls/Actions/ConnectConf.cs
+++ b/src/Sinch/Voice/Calls/Actions/ConnectConf.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Actions
 {
@@ -10,6 +11,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     The unique identifier of the conference. Shouldn&#39;t exceed 64 characters.
         /// </summary>
+        [JsonPropertyName("conferenceId")]
 #if NET7_0_OR_GREATER
         public required string ConferenceId { get; set; }
 #else
@@ -20,6 +22,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     Gets or Sets ConferenceDtmfOptions
         /// </summary>
+        [JsonPropertyName("conferenceDtmfOptions")]
         public ConferenceDtmfOptions ConferenceDtmfOptions { get; set; }
 
 
@@ -28,6 +31,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     a conference while they&#39;re alone and waiting for other participants to join. If &#x60;moh&#x60; isn&#39;t
         ///     specified, the user will only hear silence while alone in the conference.
         /// </summary>
+        [JsonPropertyName("moh")]
         public MohClass Moh { get; set; }
 
         public string Name { get; } = "connectConf";

--- a/src/Sinch/Voice/Calls/Actions/ConnectMxp.cs
+++ b/src/Sinch/Voice/Calls/Actions/ConnectMxp.cs
@@ -13,6 +13,7 @@ namespace Sinch.Voice.Calls.Actions
         public string Name { get; } = "connectMxp";
 
         /// <inheritdoc cref="Destination" />
+        [JsonPropertyName("destination")]
         public Destination Destination { get; set; }
 
         /// <summary>
@@ -20,6 +21,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     client. Read more about call headers
         ///     <see href="https://developers.sinch.com/docs/voice/api-reference/voice/call-headers/">here</see>.
         /// </summary>
+        [JsonPropertyName("callheaders")]
         public List<CallHeader> Callheaders { get; set; }
     }
 
@@ -32,6 +34,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     The type of the definition.
         /// </summary>
+        [JsonPropertyName("type")]
 #if NET7_0_OR_GREATER
         public required DestinationType Type { get; set; }
 #else
@@ -41,6 +44,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     The phone number or username of the desired call destination.
         /// </summary>
+        [JsonPropertyName("endpoint")]
 #if NET7_0_OR_GREATER
         public required string Endpoint { get; set; }
 #else

--- a/src/Sinch/Voice/Calls/Actions/ConnectPstn.cs
+++ b/src/Sinch/Voice/Calls/Actions/ConnectPstn.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Actions
 {
@@ -16,6 +17,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     Used to override where PSTN call is connected. If not specified, the extension the client called is used.
         /// </summary>
+        [JsonPropertyName("number")]
         public string Number { get; set; }
 
 
@@ -24,6 +26,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     country code according to &#x60;ISO 3166-1 alpha-2&#x60;. If not specified, the default locale of &#x60;en-US&#x60;
         ///     is used.
         /// </summary>
+        [JsonPropertyName("locale")]
         public string Locale { get; set; }
 
 
@@ -31,6 +34,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     The max duration of the call in seconds (max 14400 seconds). If the call is still connected at that time, it will
         ///     be automatically disconnected.
         /// </summary>
+        [JsonPropertyName("maxDuration")]
         public int? MaxDuration { get; set; }
 
 
@@ -38,6 +42,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     The max duration the call will wait in ringing unanswered state before terminating with &#x60;&#x60;&#x60;
         ///     TIMEOUT/NO ANSWER&#x60;&#x60;&#x60; on PSTN leg and &#x60;&#x60;&#x60;NA/BUSY&#x60;&#x60;&#x60;on MXP leg.
         /// </summary>
+        [JsonPropertyName("dialTimeout")]
         public int? DialTimeout { get; set; }
 
 
@@ -45,6 +50,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     Used to override the CLI (or caller ID) of the client. The phone number of the person who initiated the call is
         ///     shown as the CLI. To set your own CLI, you may use your verified number or your Dashboard virtual number.
         /// </summary>
+        [JsonPropertyName("cli")]
         public string Cli { get; set; }
 
 
@@ -52,6 +58,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     If enabled, suppresses <see href="https://developers.sinch.com/docs/voice/api-reference/voice/voice/tag/Callbacks/#tag/Callbacks/operation/ace">ACE</see> and
         ///     <see href="https://developers.sinch.com/docs/voice/api-reference/voice/voice/tag/Callbacks/#tag/Callbacks/operation/dice">DICE</see> callbacks for the call.
         /// </summary>
+        [JsonPropertyName("suppressCallbacks")]
         public bool? SuppressCallbacks { get; set; }
 
 
@@ -63,18 +70,21 @@ namespace Sinch.Voice.Calls.Actions
         ///     the callout destination requires a conference PIN code or an extension. If there is a calling party, it will hear
         ///     progress while the DTMF is sent.
         /// </summary>
+        [JsonPropertyName("dtmf")]
         public string Dtmf { get; set; }
 
 
         /// <summary>
         ///     The locale&#39;s tone to play while ringing.
         /// </summary>
+        [JsonPropertyName("indications")]
         public string Indications { get; set; }
 
 
         /// <summary>
         ///     An optional property used to enable <see href="https://developers.sinch.com/docs/voice/api-reference/amd_v2">Answering Machine Detection (AMD).</see>
         /// </summary>
+        [JsonPropertyName("amd")]
         public Amd Amd { get; set; }
 
 
@@ -107,6 +117,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     Sets whether AMD is enabled.
         /// </summary>
+        [JsonPropertyName("enabled")]
         public bool? Enabled { get; set; }
     }
 }

--- a/src/Sinch/Voice/Calls/Actions/ConnectSip.cs
+++ b/src/Sinch/Voice/Calls/Actions/ConnectSip.cs
@@ -13,6 +13,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     Gets or Sets Destination
         /// </summary>
+        [JsonPropertyName("destination")]
 #if NET7_0_OR_GREATER
         public required ConnectSipDestination Destination { get; set; }
 #else
@@ -24,6 +25,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     The max duration of the call in seconds (max 14400 seconds). If the call is still connected at that time, it will
         ///     be automatically disconnected.
         /// </summary>
+        [JsonPropertyName("maxDuration")]
         public int? MaxDuration { get; set; }
 
 
@@ -31,12 +33,14 @@ namespace Sinch.Voice.Calls.Actions
         ///     Used to override the CLI (or caller ID) of the client. The phone number of the person who initiated the call is
         ///     shown as the CLI. To set your own CLI, you may use your verified number or your Dashboard virtual number.
         /// </summary>
+        [JsonPropertyName("cli")]
         public string Cli { get; set; }
 
 
         /// <summary>
         ///     An optional parameter to specify the SIP transport protocol. If unspecified, UDP is used.
         /// </summary>
+        [JsonPropertyName("transport")]
         public Transport Transport { get; set; }
 
 
@@ -53,6 +57,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     </see>
         ///     callbacks for the call.
         /// </summary>
+        [JsonPropertyName("suppressCallbacks")]
         public bool? SuppressCallbacks { get; set; }
 
 
@@ -64,6 +69,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     </see>
         ///     to send with the call.
         /// </summary>
+        [JsonPropertyName("callHeaders")]
         public List<CallHeader> CallHeaders { get; set; }
 
 
@@ -72,6 +78,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     if the SIP call is placed on hold. If &#x60;moh&#x60; isn&#39;t specified and the SIP call is placed on hold, the
         ///     user will only hear silence while during the holding period .
         /// </summary>
+        [JsonPropertyName("moh")]
         public MohClass Moh { get; set; }
 
         public string Name { get; } = "connectSip";
@@ -114,6 +121,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     The SIP address.
         /// </summary>
+        [JsonPropertyName("endpoint")]
 #if NET7_0_OR_GREATER
         public required string Endpoint { get; set; }
 #else

--- a/src/Sinch/Voice/Calls/Actions/IAction.cs
+++ b/src/Sinch/Voice/Calls/Actions/IAction.cs
@@ -15,6 +15,7 @@ namespace Sinch.Voice.Calls.Actions
     [JsonDerivedType(typeof(RunMenu))]
     public interface IAction
     {
+        [JsonPropertyName("name")]
         public string Name { get; }
     }
 }

--- a/src/Sinch/Voice/Calls/Actions/Park.cs
+++ b/src/Sinch/Voice/Calls/Actions/Park.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Actions
 {
@@ -16,6 +17,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     locale and language code or by specifying a particular voice. Supported languages and voices are detailed
         ///     <see href="https://developers.sinch.com/docs/voice/api-reference/voice/voice-locales">here</see>.
         /// </summary>
+        [JsonPropertyName("locale")]
         public string Locale { get; set; }
 
 
@@ -23,6 +25,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     That prompt that is played when the call is first answered. You can use text-to-speech using the &#x60;#tts[]&#x60;
         ///     element, SSML commands using the &#x60;#ssml[]&#x60; element.
         /// </summary>
+        [JsonPropertyName("introPromt")]
         public string IntroPrompt { get; set; }
 
 
@@ -31,12 +34,14 @@ namespace Sinch.Voice.Calls.Actions
         ///     reached. You can use text-to-speech using the &#x60;#tts[]&#x60; element, SSML commands using the &#x60;#ssml[]
         ///     &#x60; element.
         /// </summary>
+        [JsonPropertyName("holdPrompt")]
         public string HoldPrompt { get; set; }
 
 
         /// <summary>
         ///     The maximum amount of time in seconds that the &#x60;holdPrompt&#x60; will be played.
         /// </summary>
+        [JsonPropertyName("maxDuration")]
         public int? MaxDuration { get; set; }
 
 

--- a/src/Sinch/Voice/Calls/Actions/RunMenu.cs
+++ b/src/Sinch/Voice/Calls/Actions/RunMenu.cs
@@ -25,6 +25,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     input is pressed, the message will stop playing and accept the input. If &#x60;barge&#x60; is disabled, the user
         ///     must listen to the entire prompt before input is accepted. By default, barging is enabled.
         /// </summary>
+        [JsonPropertyName("badge")]
         public bool? Barge { get; set; }
 
 
@@ -35,12 +36,14 @@ namespace Sinch.Voice.Calls.Actions
         ///     &#x60; to enable voice detection, the &#x60;locale&#x60;
         ///     property is required in order to select the input language.
         /// </summary>
+        [JsonPropertyName("locale")]
         public string Locale { get; set; }
 
 
         /// <summary>
         ///     Selects the menu item from the &#x60;menus&#x60; array to play first.
         /// </summary>
+        [JsonPropertyName("mainMenu")]
         public string MainMenu { get; set; }
 
 
@@ -48,6 +51,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     Enables voice detection. If enabled, users can say their answers to prompts in addition to entering them using the
         ///     keypad.
         /// </summary>
+        [JsonPropertyName("enableVoice")]
         public bool? EnableVoice { get; set; }
 
 
@@ -55,6 +59,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     The list of menus available. The menu with the &#x60;id&#x60; value of &#x60;main&#x60; will always play first. If
         ///     no menu has an &#x60;id&#x60; value of &#x60;main&#x60;, an error is returned.
         /// </summary>
+        [JsonPropertyName("menus")]
         public List<Menu> Menus { get; set; }
 
         public string Name { get; } = "runMenu";
@@ -87,6 +92,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     The identifier of a menu. One menu must have the ID value of &#x60;main&#x60;.
         /// </summary>
+        [JsonPropertyName("id")]
 #if NET7_0_OR_GREATER
         public required string Id { get; set; }
 #else
@@ -105,6 +111,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     section for
         ///     more information.
         /// </summary>
+        [JsonPropertyName("mainPrompt")]
         public string MainPrompt { get; set; }
 
 
@@ -119,12 +126,14 @@ namespace Sinch.Voice.Calls.Actions
         ///     section for
         ///     more information.
         /// </summary>
+        [JsonPropertyName("repeatPrompt")]
         public string RepeatPrompt { get; set; }
 
 
         /// <summary>
         ///     The number of times that the &#x60;repeatPrompt&#x60; is played.
         /// </summary>
+        [JsonPropertyName("repeats")]
         public int? Repeats { get; set; }
 
 
@@ -137,6 +146,7 @@ namespace Sinch.Voice.Calls.Actions
         ///     </see>
         ///     is triggered containing these digits.
         /// </summary>
+        [JsonPropertyName("maxDigits")]
         public int? MaxDigits { get; set; }
 
 
@@ -144,18 +154,21 @@ namespace Sinch.Voice.Calls.Actions
         ///     Determines silence for the purposes of collecting a DTMF or voice response in milliseconds. If the timeout is
         ///     reached, the response is considered completed and will be submitted.
         /// </summary>
+        [JsonPropertyName("timeoutMills")]
         public int? TimeoutMills { get; set; }
 
 
         /// <summary>
         ///     Sets a limit for the maximum amount of time allowed to collect voice input.
         /// </summary>
+        [JsonPropertyName("maxTimeoutMills")]
         public int? MaxTimeoutMills { get; set; }
 
 
         /// <summary>
         ///     The set of options available in the menu.
         /// </summary>
+        [JsonPropertyName("options")]
         public List<Option> Options { get; set; }
 
 
@@ -188,6 +201,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     A DTMF digit the user can press to trigger the configured action.
         /// </summary>
+        [JsonPropertyName("dtmf")]
 #if NET7_0_OR_GREATER
         public required string Dtmf { get; set; }
 #else
@@ -198,6 +212,7 @@ namespace Sinch.Voice.Calls.Actions
         /// <summary>
         ///     Determines which action is taken when the DTMF digit is pressed.
         /// </summary>
+        [JsonPropertyName("action")]
 #if NET7_0_OR_GREATER
         public required DtmfAction Action { get; set; }
 #else

--- a/src/Sinch/Voice/Calls/Instructions/IInstruction.cs
+++ b/src/Sinch/Voice/Calls/Instructions/IInstruction.cs
@@ -14,6 +14,7 @@ namespace Sinch.Voice.Calls.Instructions
     [JsonDerivedType(typeof(StopRecording))]
     public interface IInstruction
     {
+        [JsonPropertyName("name")]
         public string Name { get; }
     }
 }

--- a/src/Sinch/Voice/Calls/Instructions/PlayFiles.cs
+++ b/src/Sinch/Voice/Calls/Instructions/PlayFiles.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Instructions
 {
@@ -14,6 +15,7 @@ namespace Sinch.Voice.Calls.Instructions
         ///     &#x60; element, or text using the &#x60;#tts[]&#x60; element.
         ///     <example>[ ["Welcome","https://path/to/file"], ["#ssml[Thank you for calling Sinch!]"] ]</example>
         /// </summary>
+        [JsonPropertyName("ids")]
 #if NET7_0_OR_GREATER
         public required List<List<string>> Ids { get; set; }
 #else
@@ -27,6 +29,7 @@ namespace Sinch.Voice.Calls.Instructions
         ///     Supported languages and voices are detailed here:
         ///     https://developers.sinch.com/docs/voice/api-reference/voice/voice-locales
         /// </summary>
+        [JsonPropertyName("locale")]
 #if NET7_0_OR_GREATER
         public required string Locale { get; set; }
 #else

--- a/src/Sinch/Voice/Calls/Instructions/Say.cs
+++ b/src/Sinch/Voice/Calls/Instructions/Say.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Instructions
 {
@@ -7,12 +8,14 @@ namespace Sinch.Voice.Calls.Instructions
     /// </summary>
     public sealed class Say : IInstruction
     {
+        [JsonPropertyName("name")]
         public string Name { get; } = "say";
         
         /// <summary>
         ///     Contains the message that will be spoken. Default maximum length is 600 characters. To change this limit, please
         ///     contact support.
         /// </summary>
+        [JsonPropertyName("text")]
         public string Text { get; set; }
 
         /// <summary>
@@ -20,6 +23,7 @@ namespace Sinch.Voice.Calls.Instructions
         ///     locale and language code or by specifying a particular voice. Supported languages and voices are detailed here:
         ///     https://developers.sinch.com/docs/voice/api-reference/voice/voice-locales.
         /// </summary>
+        [JsonPropertyName("locale")]
         public string Locale { get; set; }
 
         /// <summary>

--- a/src/Sinch/Voice/Calls/Instructions/SendDtmf.cs
+++ b/src/Sinch/Voice/Calls/Instructions/SendDtmf.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Instructions
 {
@@ -17,6 +18,7 @@ namespace Sinch.Voice.Calls.Instructions
         ///     the callout destination requires a conference PIN code or an extension. If there is a calling party, it will hear
         ///     progress while the DTMF is sent.
         /// </summary>
+        [JsonPropertyName("value")]
         public string Value { get; set; }
 
 

--- a/src/Sinch/Voice/Calls/Instructions/SetCookie.cs
+++ b/src/Sinch/Voice/Calls/Instructions/SetCookie.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.Calls.Instructions
 {
@@ -12,12 +13,14 @@ namespace Sinch.Voice.Calls.Instructions
         /// <summary>
         ///     The name of the cookie you want to set.
         /// </summary>
+        [JsonPropertyName("key")]
         public string Key { get; set; }
 
 
         /// <summary>
         ///     The value of the cookie you want to set.
         /// </summary>
+        [JsonPropertyName("value")]
         public string Value { get; set; }
 
 

--- a/src/Sinch/Voice/Calls/Instructions/StartRecording.cs
+++ b/src/Sinch/Voice/Calls/Instructions/StartRecording.cs
@@ -1,4 +1,6 @@
-﻿namespace Sinch.Voice.Calls.Instructions
+﻿using System.Text.Json.Serialization;
+
+namespace Sinch.Voice.Calls.Instructions
 {
     /// <summary>
     ///     Starts a recording of the call.
@@ -12,6 +14,7 @@
         ///     https://developers.sinch.com/docs/in-app-calling/voice-recording/#recording-options
         /// </summary>
         // TODO: check if class is correct
+        [JsonPropertyName("options")]
         public StartRecordingOptions Options { get; set; }
     }
 
@@ -30,17 +33,20 @@
         ///     To read more about how to configure each of these destinations, see the
         ///     DestinationURL(https://developers.sinch.com/docs/in-app-calling/voice-recording/#destinationurl) section.
         /// </summary>
+        [JsonPropertyName("destinationUrl")]
         public string DestinationUrl { get; set; }
 
         /// <summary>
         ///     Specifies the information required for the Sinch platform to authenticate and/or authorize in the destination
         ///     service in order to be able to store the file.
         /// </summary>
+        [JsonPropertyName("credentials")]
         public string Credentials { get; set; }
 
         /// <summary>
         ///     An optional property that specifies the format of the recording file. Default value is mp3.
         /// </summary>
+        [JsonPropertyName("format")]
         public string Format { get; set; }
 
         /// <summary>
@@ -49,6 +55,7 @@
         ///     see the Notification Events (https://developers.sinch.com/docs/in-app-calling/voice-recording/#notification-events)
         ///     section. Default value is “true”
         /// </summary>
+        [JsonPropertyName("notificationEvents")]
         public bool? NotificationEvents { get; set; }
     }
 }

--- a/src/Sinch/Voice/ConferenceDtmfOptions.cs
+++ b/src/Sinch/Voice/ConferenceDtmfOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Sinch.Voice
+﻿using System.Text.Json.Serialization;
+
+namespace Sinch.Voice
 {
     /// <summary>
     ///     Options to control how DTMF signals are used by the participant in the conference.
@@ -10,6 +12,7 @@
         /// <summary>
         ///     Determines what DTMF mode the participant will use in the call.
         /// </summary>
+        [JsonPropertyName("mode")]
         public DtmfMode Mode { get; set; }
 
         /// <summary>
@@ -22,12 +25,14 @@
         ///         <item>The maximum number of digits has been entered.</item>
         ///     </list>
         /// </summary>
+        [JsonPropertyName("maxDigits")]
         public int? MaxDigits { get; set; }
 
         /// <summary>
         ///     The number of milliseconds that the system will wait between entered digits before triggering the PIE callback.
         ///     The default value is <c>3000</c>.
         /// </summary>
+        [JsonPropertyName("timeoutMills")]
         public int? TimeoutMills { get; set; }
     }
 }

--- a/src/Sinch/Voice/Hooks/AnsweredCallEvent.cs
+++ b/src/Sinch/Voice/Hooks/AnsweredCallEvent.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using Sinch.Voice.Calls.Actions;
+
+namespace Sinch.Voice.Hooks
+{
+    /// <summary>
+    ///     This callback is made when the call is picked up by the callee (person receiving the call). It's a POST request to
+    ///     the specified calling callback URL. Look here for allowed
+    ///     [instructions](https://developers.sinch.com/docs/voice/api-reference/svaml/instructions) and
+    ///     [actions](https://developers.sinch.com/docs/voice/api-reference/svaml/actions).
+    ///     If there is no response to the callback within the timeout period, the call is connected.
+    ///     If you have [Answering Machine Detection (AMD)](https://developers.sinch.com/docs/voice/api-reference/amd_v2)
+    ///     enabled, the amd object will also be present on ACE callbacks.
+    ///     Note: ACE Callbacks are not issued for InApp Calls (destination: username), only PSTN and SIP calls.
+    /// </summary>
+    public class AnsweredCallEvent
+    {
+        /// <summary>
+        ///     Must have the value ace.
+        /// </summary>
+        [JsonPropertyName("event")]
+        public string Event { get; }
+
+
+        /// <summary>
+        ///     The unique ID assigned to this call.
+        /// </summary>
+        [JsonPropertyName("callId")]
+        public string CallId { get; set; }
+
+
+        /// <summary>
+        ///     The path of the API resource.
+        /// </summary>
+        [JsonPropertyName("callResourceUrl")]
+        public string CallResourceUrl { get; set; }
+
+
+        /// <summary>
+        ///     The timestamp in UTC format.
+        /// </summary>
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+
+        /// <summary>
+        ///     The current API version.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+
+        /// <summary>
+        ///     A string that can be used to pass custom information related to the call.
+        /// </summary>
+        [JsonPropertyName("custom")]
+        public string Custom { get; set; }
+
+        /// <summary>
+        ///     If [Answering Machine Detection (AMD)](https://developers.sinch.com/docs/voice/api-reference/amd_v2) is enabled,
+        ///     this object contains information about whether the call was answered by a machine.
+        /// </summary>
+        [JsonPropertyName("amd")]
+        public Amd Amd { get; set; }
+    }
+}

--- a/src/Sinch/Voice/Hooks/CallEventResponse.cs
+++ b/src/Sinch/Voice/Hooks/CallEventResponse.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using Sinch.Voice.Calls.Actions;
+using Sinch.Voice.Calls.Instructions;
+
+namespace Sinch.Voice.Hooks
+{
+    /// <summary>
+    ///     The Incoming Call Event (ICE) or The Answered Call Event (ACE) requires a valid SVAML object in response.
+    /// </summary>
+    public class CallEventResponse
+    {
+        /// <summary>
+        ///     The collection of instructions that can perform various tasks during the call. You can include as many instructions
+        ///     as necessary.
+        /// </summary>
+        [JsonPropertyName("instructions")]
+        public List<IInstruction> Instructions { get; set; }
+
+        /// <summary>
+        ///     The action that will control the call. Each SVAML object can only include one action.
+        /// </summary>
+        [JsonPropertyName("action")]
+        public IAction Action { get; set; }
+    }
+}

--- a/src/Sinch/Voice/Hooks/DisconnectedCallEvent.cs
+++ b/src/Sinch/Voice/Hooks/DisconnectedCallEvent.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+using Sinch.Voice.Calls;
+using Sinch.Voice.Calls.Actions;
+
+namespace Sinch.Voice.Hooks
+{
+    /// <summary>
+    ///     This callback is made when the call is disconnected. It's a POST request to the specified calling callback URL.
+    ///     This event doesn't support instructions and only supports the
+    ///     [hangup](https://developers.sinch.com/docs/voice/api-reference/svaml/actions/#hangup) action.
+    /// </summary>
+    public class DisconnectedCallEvent
+    {
+        /// <summary>
+        ///     Must have the value &#x60;dice&#x60;.
+        /// </summary>
+        [JsonPropertyName("event")]
+        public string Event { get; set; }
+
+
+        /// <summary>
+        ///     The unique ID assigned to this call.
+        /// </summary>
+        [JsonPropertyName("callId")]
+        public string CallId { get; set; }
+
+
+        /// <summary>
+        ///     The timestamp in UTC format.
+        /// </summary>
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+
+        /// <summary>
+        ///     The reason the call was disconnected.
+        /// </summary>
+        [JsonPropertyName("reason")]
+        public CallResultReason Reason { get; set; }
+
+
+        /// <summary>
+        ///     The result of the call.
+        /// </summary>
+        [JsonPropertyName("result")]
+        public CallResult Result { get; set; }
+
+
+        /// <summary>
+        ///     The current API version.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+
+        /// <summary>
+        ///     A string that can be used to pass custom information related to the call.
+        /// </summary>
+        [JsonPropertyName("custom")]
+        public string Custom { get; set; }
+
+
+        /// <summary>
+        ///     Gets or Sets Debit
+        /// </summary>
+        [JsonPropertyName("debit")]
+        public Rate Debit { get; set; }
+
+
+        /// <summary>
+        ///     Gets or Sets UserRate
+        /// </summary>
+        [JsonPropertyName("userRate")]
+        public Rate UserRate { get; set; }
+
+
+        /// <summary>
+        ///     Gets or Sets To
+        /// </summary>
+        [JsonPropertyName("to")]
+        public To To { get; set; }
+
+
+        /// <summary>
+        ///     The duration of the call in seconds.
+        /// </summary>
+        [JsonPropertyName("duration")]
+        public int Duration { get; set; }
+
+
+        /// <summary>
+        ///     Information about the initiator of the call.
+        /// </summary>
+        [JsonPropertyName("from")]
+        public string From { get; set; }
+
+
+        /// <summary>
+        ///     If the call was initiated by a Sinch SDK client, call headers are the headers specified by the *caller* client.
+        ///     Read more about call headers [here](../../../call-headers/).
+        /// </summary>
+        [JsonPropertyName("callHeaders")]
+        public List<CallHeader> CallHeaders { get; set; }
+
+
+        /// <summary>
+        ///     The unique application key. You can find it in the Sinch [dashboard](https://dashboard.sinch.com/voice/apps).
+        /// </summary>
+        [JsonPropertyName("applicationKey")]
+        public string ApplicationKey { get; set; }
+
+
+        /// <summary>
+        ///     Returns the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class DiceRequest {\n");
+            sb.Append("  VarEvent: ").Append(Event).Append("\n");
+            sb.Append("  CallId: ").Append(CallId).Append("\n");
+            sb.Append("  Timestamp: ").Append(Timestamp).Append("\n");
+            sb.Append("  Reason: ").Append(Reason).Append("\n");
+            sb.Append("  Result: ").Append(Result).Append("\n");
+            sb.Append("  VarVersion: ").Append(Version).Append("\n");
+            sb.Append("  Custom: ").Append(Custom).Append("\n");
+            sb.Append("  Debit: ").Append(Debit).Append("\n");
+            sb.Append("  UserRate: ").Append(UserRate).Append("\n");
+            sb.Append("  To: ").Append(To).Append("\n");
+            sb.Append("  Duration: ").Append(Duration).Append("\n");
+            sb.Append("  From: ").Append(From).Append("\n");
+            sb.Append("  CallHeaders: ").Append(CallHeaders).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+}

--- a/src/Sinch/Voice/Hooks/IncomingCallEvent.cs
+++ b/src/Sinch/Voice/Hooks/IncomingCallEvent.cs
@@ -1,0 +1,161 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json.Serialization;
+using Sinch.Core;
+using Sinch.Voice.Calls;
+using Sinch.Voice.Calls.Actions;
+
+namespace Sinch.Voice.Hooks
+{
+    /// <summary>
+    ///     When a call reaches the Sinch platform, the system makes a POST request to the specified calling callback URL.
+    ///     This event, called the ICE event, can be triggered by either an incoming data call or an incoming PSTN call. Look
+    ///     here for allowed instructions and actions.
+    ///     If there is no response to the callback within the timeout period, an error message is played, and the call is
+    ///     disconnected.
+    /// </summary>
+    public class IncomingCallEvent
+    {
+        /// <summary>
+        ///     Must have the value ice.
+        /// </summary>
+        [JsonPropertyName("event")]
+        public string Event { get; set; }
+
+
+        /// <summary>
+        ///     The unique ID assigned to this call.
+        /// </summary>
+        [JsonPropertyName("callId")]
+        public string CallId { get; set; }
+
+
+        /// <summary>
+        ///     The path of the API resource.
+        /// </summary>
+        [JsonPropertyName("callResourceUrl")]
+        public string CallResourceUrl { get; set; }
+
+
+        /// <summary>
+        ///     The timestamp in UTC format.
+        /// </summary>
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+
+        /// <summary>
+        ///     The current API version.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+
+        /// <summary>
+        ///     A string that can be used to pass custom information related to the call.
+        /// </summary>
+        [JsonPropertyName("custom")]
+        public string Custom { get; set; }
+
+
+        /// <summary>
+        ///     Gets or Sets UserRate
+        /// </summary>
+        [JsonPropertyName("userRate")]
+        public Rate UserRate { get; set; }
+
+
+        /// <summary>
+        ///     The number that will be displayed to the recipient of the call. To set your own CLI, you may use your verified
+        ///     number or your Dashboard virtual number and add it to the &#x60;connectPSTN&#x60; SVAML response to the Incoming
+        ///     Call Event request.  It must be in [E.164](https://community.sinch.com/t5/Glossary/E-164/ta-p/7537) format.
+        /// </summary>
+        [JsonPropertyName("cli")]
+        public string Cli { get; set; }
+
+
+        /// <summary>
+        ///     Gets or Sets To
+        /// </summary>
+        [JsonPropertyName("to")]
+        public To To { get; set; }
+
+
+        /// <summary>
+        ///     The domain destination of the incoming call.
+        /// </summary>
+        [JsonPropertyName("domain")]
+        public CallDomain Domain { get; set; }
+
+
+        /// <summary>
+        ///     The unique application key. You can find it in the Sinch [dashboard](https://dashboard.sinch.com/voice/apps).
+        /// </summary>
+        [JsonPropertyName("applicationKey")]
+        public string ApplicationKey { get; set; }
+
+
+        /// <summary>
+        ///     The origination domain of the incoming call.
+        /// </summary>
+        [JsonPropertyName("originationType")]
+        public OriginationType OriginationType { get; set; }
+
+
+        /// <summary>
+        ///     The duration of the call in seconds.
+        /// </summary>
+        [JsonPropertyName("duration")]
+        public int Duration { get; set; }
+
+
+        /// <summary>
+        ///     The redirected dialled number identification service.
+        /// </summary>
+        [JsonPropertyName("rdnis")]
+        public string Rdnis { get; set; }
+
+
+        /// <summary>
+        ///     If the call is initiated by a Sinch SDK client, call headers are the headers specified by the *caller* client. Read
+        ///     more about call headers [here](https://developers.sinch.com/docs/voice/api-reference/call-headers).
+        /// </summary>
+        [JsonPropertyName("callHeaders")]
+        public List<CallHeader> CallHeaders { get; set; }
+
+
+        /// <summary>
+        ///     Returns the string presentation of the object
+        /// </summary>
+        /// <returns>String presentation of the object</returns>
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            sb.Append("class IceRequest {\n");
+            sb.Append("  VarEvent: ").Append(Event).Append("\n");
+            sb.Append("  CallId: ").Append(CallId).Append("\n");
+            sb.Append("  CallResourceUrl: ").Append(CallResourceUrl).Append("\n");
+            sb.Append("  Timestamp: ").Append(Timestamp).Append("\n");
+            sb.Append("  VarVersion: ").Append(Version).Append("\n");
+            sb.Append("  Custom: ").Append(Custom).Append("\n");
+            sb.Append("  UserRate: ").Append(UserRate).Append("\n");
+            sb.Append("  Cli: ").Append(Cli).Append("\n");
+            sb.Append("  To: ").Append(To).Append("\n");
+            sb.Append("  Domain: ").Append(Domain).Append("\n");
+            sb.Append("  OriginationType: ").Append(OriginationType).Append("\n");
+            sb.Append("  Duration: ").Append(Duration).Append("\n");
+            sb.Append("  Rdnis: ").Append(Rdnis).Append("\n");
+            sb.Append("  CallHeaders: ").Append(CallHeaders).Append("\n");
+            sb.Append("}\n");
+            return sb.ToString();
+        }
+    }
+
+    [JsonConverter(typeof(EnumRecordJsonConverter<OriginationType>))]
+    public record OriginationType(string Value) : EnumRecord(Value)
+    {
+        public static readonly OriginationType Pstn = new("pstn");
+        public static readonly OriginationType Mxp = new("mxp");
+    }
+}

--- a/src/Sinch/Voice/Hooks/NotificationEvent.cs
+++ b/src/Sinch/Voice/Hooks/NotificationEvent.cs
@@ -1,0 +1,42 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sinch.Voice.Hooks
+{
+    /// <summary>
+    ///     This is the general callback used to send notifications. It's a POST request to the specified calling callback URL.
+    ///     <br /><br />
+    ///     If there is no response to the callback within the timeout period, the notification is discarded.
+    /// </summary>
+    public class NotificationEvent
+    {
+        /// <summary>
+        ///     Must have the value notify.
+        /// </summary>
+        [JsonPropertyName("event")]
+        public string Event { get; set; }
+
+        /// <summary>
+        ///     The unique ID assigned to this call.
+        /// </summary>
+        [JsonPropertyName("callId")]
+        public string CallId { get; set; }
+
+        /// <summary>
+        ///     The current API version.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+        /// <summary>
+        ///     The type of information communicated in the notification.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        ///     A string that can be used to pass custom information related to the call.
+        /// </summary>
+        [JsonPropertyName("custom")]
+        public string Custom { get; set; }
+    }
+}

--- a/src/Sinch/Voice/Hooks/PromtInputEvent.cs
+++ b/src/Sinch/Voice/Hooks/PromtInputEvent.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Text.Json.Serialization;
+using Sinch.Core;
+
+namespace Sinch.Voice.Hooks
+{
+    /// <summary>
+    ///     This callback is triggered as a result of a
+    ///     [runMenu](https://developers.sinch.com/docs/voice/api-reference/svaml/actions/#runmenu) action. It can be triggered
+    ///     from either a user pressing a number of DTMF digits, or by the return command.
+    ///     <br /><br />
+    ///     It's a POST request to the specified calling callback URL. Your application can respond with
+    ///     [SVAML](https://developers.sinch.com/docs/voice/api-reference/svaml/) logic.<br /><br />
+    ///     Note: PIE callbacks are not issued for DATA Calls, only PSTN and SIP calls.
+    /// </summary>
+    public class PromptInputEvent
+    {
+        /// <summary>
+        ///     Must have the value pie.
+        /// </summary>
+        [JsonPropertyName("event")]
+        public string Event { get; set; } 
+
+        /// <summary>
+        ///     The unique ID assigned to this call.
+        /// </summary>
+        [JsonPropertyName("callId")]
+        public string CallId { get; set; }
+
+        /// <summary>
+        ///     The timestamp in UTC format.
+        /// </summary>
+        [JsonPropertyName("timestamp")]
+        public DateTime Timestamp { get; set; }
+
+        /// <summary>
+        ///     An object containing information about the returned menu result.
+        /// </summary>
+        [JsonPropertyName("menuResult")]
+        public MenuResult MenuResult { get; set; }
+
+        /// <summary>
+        ///     The current API version.
+        /// </summary>
+        [JsonPropertyName("version")]
+        public int Version { get; set; }
+
+        /// <summary>
+        ///     The unique application key. You can find it in the Sinch [dashboard](https://dashboard.sinch.com/voice/apps).
+        /// </summary>
+        [JsonPropertyName("applicationKey")]
+        public string ApplicationKey { get; set; }
+    }
+
+    public class MenuResult
+    {
+        /// <summary>
+        ///     The ID of the menu that triggered the prompt input event.
+        /// </summary>
+        [JsonPropertyName("menuId")]
+        public string MenuId { get; set; }
+
+        /// <summary>
+        ///     The type of information that's returned.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public MenuType Type { get; set; }
+
+        /// <summary>
+        ///     The value of the returned information.
+        /// </summary>
+        [JsonPropertyName("value")]
+        public string Value { get; set; }
+
+        /// <summary>
+        ///     The type of input received.
+        /// </summary>
+        [JsonPropertyName("inputMethod")]
+        public InputMethod InputMethod { get; set; }
+    }
+
+    [JsonConverter(typeof(EnumRecordJsonConverter<MenuType>))]
+    public record MenuType(string Value) : EnumRecord(Value)
+    {
+        /// <summary>
+        ///     Returned if there's an error with the input.
+        /// </summary>
+        public static readonly MenuType Error = new("Error");
+
+        /// <summary>
+        ///     Returned when the event has been triggered from a return command.
+        /// </summary>
+        public static readonly MenuType Return = new("Return");
+
+        /// <summary>
+        ///     Returned when the event has been triggered from collecting DTMF digits.
+        /// </summary>
+        public static readonly MenuType Sequence = new("Sequence");
+
+        /// <summary>
+        ///     Returned when the timeout period has elapsed.
+        /// </summary>
+        public static readonly MenuType Timeout = new("Timeout");
+
+        /// <summary>
+        ///     Returned when the call is hung up.
+        /// </summary>
+        public static readonly MenuType Hangup = new("Hangup");
+
+        /// <summary>
+        ///     Returned when the value of the input is invalid.
+        /// </summary>
+        public static readonly MenuType InvalidInput = new("InvalidInput");
+    }
+
+    [JsonConverter(typeof(EnumRecordJsonConverter<InputMethod>))]
+    public record InputMethod(string Value) : EnumRecord(Value)
+    {
+        /// <summary>
+        ///     The input is key presses of specified digits.
+        /// </summary>
+        public static readonly InputMethod Dtmf = new("dtmf");
+
+        /// <summary>
+        ///     The input is voice answers.
+        /// </summary>
+        public static readonly InputMethod Voice = new("voice");
+    }
+}

--- a/src/Sinch/Voice/Hooks/To.cs
+++ b/src/Sinch/Voice/Hooks/To.cs
@@ -1,0 +1,22 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sinch.Voice.Hooks
+{
+    /// <summary>
+    ///     An object containing information about the recipient of the call.
+    /// </summary>
+    public class To
+    {
+        /// <summary>
+        ///     The type of the destination.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        ///     The phone number, user name, or other identifier of the destination.
+        /// </summary>
+        [JsonPropertyName("endpoint")]
+        public string Endpoint { get; set; }
+    }
+}

--- a/src/Sinch/Voice/Rate.cs
+++ b/src/Sinch/Voice/Rate.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text;
+using System.Text.Json.Serialization;
 
-namespace Sinch.Voice.Applications.QueryNumber
+namespace Sinch.Voice
 {
     /// <summary>
     ///     The cost per minute to call the destination number.
@@ -10,12 +11,14 @@ namespace Sinch.Voice.Applications.QueryNumber
         /// <summary>
         ///     The currency ID of the rate, for example, &#x60;USD&#x60;.
         /// </summary>
+        [JsonPropertyName("currencyId")]
         public string CurrencyId { get; set; }
 
 
         /// <summary>
         ///     The amount.
         /// </summary>
+        [JsonPropertyName("amount")]
         public decimal Amount { get; set; }
 
 

--- a/tests/Sinch.Tests/e2e/Voice/ApplicationsTests.cs
+++ b/tests/Sinch.Tests/e2e/Voice/ApplicationsTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Sinch.Voice;
 using Sinch.Voice.Applications;
 using Sinch.Voice.Applications.GetNumbers;
 using Sinch.Voice.Applications.QueryNumber;


### PR DESCRIPTION
Add classes for use with [Voice Callbacks](https://developers.sinch.com/docs/voice/api-reference/voice/tag/Callbacks/)
Add JsonPropertyNames for related callback classes to override json naming convention of any used json serializer