### PR TITLE
feat: allow to override api url with SinchOptions.cs

### DIFF
--- a/src/Sinch/Auth/OAuth.cs
+++ b/src/Sinch/Auth/OAuth.cs
@@ -22,17 +22,12 @@ namespace Sinch.Auth
 
         public string Scheme { get; } = AuthSchemes.Bearer;
 
-        public OAuth(string keyId, string keySecret, HttpClient httpClient, ILoggerAdapter<OAuth> logger)
+        public OAuth(string keyId, string keySecret, HttpClient httpClient, ILoggerAdapter<OAuth> logger, Uri baseAddress)
         {
             _keyId = keyId;
             _keySecret = keySecret;
             _httpClient = httpClient;
             _logger = logger;
-            _baseAddress = new Uri("https://auth.sinch.com");
-        }
-
-        internal OAuth(Uri baseAddress, HttpClient httpClient) : this("", "", httpClient, null)
-        {
             _baseAddress = baseAddress;
         }
 

--- a/src/Sinch/SinchOptions.cs
+++ b/src/Sinch/SinchOptions.cs
@@ -35,5 +35,44 @@ namespace Sinch
         ///     Defaults to "us"
         /// </summary>
         public ConversationRegion ConversationRegion { get; set; } = ConversationRegion.Us;
+
+        /// <inheritdoc cref="ApiUrlOverrides"/>
+        public ApiUrlOverrides ApiUrlOverrides { get; set; }
+    }
+
+    /// <summary>
+    ///     If you want to set your own url for proxy or testing, you can do it here for each API endpoint.
+    /// </summary>
+    public sealed class ApiUrlOverrides
+    {
+        /// <summary>
+        ///     Overrides SMS api base url
+        /// </summary>
+        public string SmsUrl { get; init; }
+
+        /// <summary>
+        ///     Overrides Conversation api base url
+        /// </summary>
+        public string ConversationUrl { get; init; }
+
+        /// <summary>
+        ///     Overrides Voice api base url
+        /// </summary>
+        public string VoiceUrl { get; init; }
+
+        /// <summary>
+        ///     Overrides Verification api base url
+        /// </summary>
+        public string VerificationUrl { get; init; }
+        
+        /// <summary>
+        ///     Overrides Auth api base url
+        /// </summary>
+        public string AuthUrl { get; init; }
+
+        /// <summary>
+        ///     Overrides Numbers api base url
+        /// </summary>
+        public string NumbersUrl { get; init; }
     }
 }

--- a/tests/Sinch.Tests/AuthTests.cs
+++ b/tests/Sinch.Tests/AuthTests.cs
@@ -26,7 +26,7 @@ namespace Sinch.Tests
             var httpClient = new HttpClient(_messageHandlerMock);
             const string mockKeyId = "mock_key_id";
             const string mockKeySecret = "mock_key_secret";
-            _auth = new OAuth(mockKeyId, mockKeySecret, httpClient, _logger);
+            _auth = new OAuth(mockKeyId, mockKeySecret, httpClient, _logger, new Uri("https://auth.sinch.com/"));
             var basicAuthHeaderValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{mockKeyId}:{mockKeySecret}"));
             _mockedRequest = _messageHandlerMock.When(HttpMethod.Post, "https://auth.sinch.com/oauth2/token")
                 .WithFormData(new[]

--- a/tests/Sinch.Tests/e2e/TestBase.cs
+++ b/tests/Sinch.Tests/e2e/TestBase.cs
@@ -15,20 +15,32 @@ namespace Sinch.Tests.e2e
         protected TestBase()
         {
             Env.Load();
-            SinchClientMockStudio = new Sinch.SinchClient(ProjectId, new Uri("http://localhost:8001"),
-                new Uri("http://localhost:8000"),
-                new Uri("http://localhost:8002"), null, null);
-            var authUri = new Uri($"http://localhost:{Environment.GetEnvironmentVariable("MOCK_AUTH_PORT")}");
-            var smsUri = new Uri($"http://localhost:{Environment.GetEnvironmentVariable("MOCK_SMS_PORT")}");
-            // TODO: use mock server endpoints
-            var numbersUri = new Uri($"http://localhost:{Environment.GetEnvironmentVariable("MOCK_NUMBERS_PORT")}");
-            var verificationBaseUri =
-                new Uri($"http://localhost:{Environment.GetEnvironmentVariable("MOCK_VERIFICATION_PORT")}");
-            var voiceBaseUri =
-                new Uri($"http://localhost:{Environment.GetEnvironmentVariable("MOCK_VOICE_PORT")}");
-            SinchClientMockServer = new Sinch.SinchClient(ProjectId, authUri,
-                new Uri("http://localhost:8000"),
-                smsUri, verificationBaseUri, voiceBaseUri);
+            SinchClientMockStudio = new SinchClient("key_id", "key_secret", ProjectId,
+                options =>
+                {
+                    options.ApiUrlOverrides = new ApiUrlOverrides()
+                    {
+                        AuthUrl = "http://localhost:8001",
+                        NumbersUrl = "http://localhost:8000",
+                        SmsUrl = "http://localhost:8002"
+                    };
+                });
+
+            SinchClientMockServer = new SinchClient("key_id", "key_secret", ProjectId, options =>
+            {
+                options.ApiUrlOverrides = new ApiUrlOverrides()
+                {
+                    AuthUrl = GetTestUrl("MOCK_AUTH_PORT"),
+                    SmsUrl = GetTestUrl("MOCK_SMS_PORT"),
+                    ConversationUrl = GetTestUrl("MOCK_CONVERSATION_PORT"),
+                    NumbersUrl = GetTestUrl("MOCK_NUMBERS_PORT"),
+                    VoiceUrl = GetTestUrl("MOCK_VOICE_PORT"),
+                    VerificationUrl = GetTestUrl("MOCK_VERIFICATION_PORT"),
+                };
+            });
         }
+
+        private string GetTestUrl(string portEnvVar) =>
+            $"http://localhost:{Environment.GetEnvironmentVariable(portEnvVar)}";
     }
 }


### PR DESCRIPTION
Now, via public api the user can override api urls. 

```
var sinchClient = new SinchClient("key_id", "key_secret", "project_id", options =>
            {
                options.ApiUrlOverrides = new ApiUrlOverrides()
                {
                    AuthUrl = "https://testauth.com",
                    SmsUrl ="https://smsproxy.com"
                };
            });
```