### PR TITLE
Feat/allow to init client without providing parameters

### DIFF
--- a/examples/Console/UseOnlyVoiceOrVerification.cs
+++ b/examples/Console/UseOnlyVoiceOrVerification.cs
@@ -1,0 +1,17 @@
+﻿using Sinch;
+
+namespace Examples
+{
+    public class UseOnlyVoiceOrVerification
+    {
+        /// <summary>
+        ///     If you want to use only voice and/or verification api, you can init sinch client without providing
+        ///     necessary credentials. But be aware that when you try to use other services which depends on the common credentials you will get an exception.
+        /// </summary>
+        public void Example()
+        {
+            var sinchVoiceClient = new SinchClient(null, null, null).Voice("appKey", "appSecret");
+            var sinchVerificationClient = new SinchClient(null, null, null).Verification("appKey", "appSecret");
+        }
+    }
+}

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using Sinch.Auth;
@@ -143,22 +144,25 @@ namespace Sinch
         private void ValidateCommonCredentials()
         {
             var exceptions = new List<Exception>();
-            if (_keyId is null)
+            if (string.IsNullOrEmpty(_keyId))
             {
                 exceptions.Add(new InvalidOperationException("keyId should have a value"));
             }
 
-            if (_projectId is null)
+            if (string.IsNullOrEmpty(_projectId))
             {
                 exceptions.Add(new InvalidOperationException("projectId should have a value"));
             }
 
-            if (_keySecret is null)
+            if (string.IsNullOrEmpty(_keySecret))
             {
                 exceptions.Add(new InvalidOperationException("keySecret should have a value"));
             }
 
-            throw new AggregateException("Credentials are missing", exceptions);
+            if (exceptions.Any())
+            {
+                throw new AggregateException("Credentials are missing", exceptions);
+            }
         }
 
         /// <summary>

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -218,7 +218,7 @@ namespace Sinch
         public ISinchSms Sms { get; }
 
         /// <inheritdoc/>
-        public ISinchConversation Conversation { get; set; }
+        public ISinchConversation Conversation { get; }
 
 
         /// <inheritdoc/>

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -181,11 +181,26 @@ namespace Sinch
             options?.Invoke(optionsObj);
 
             if (optionsObj.LoggerFactory is not null) _loggerFactory = new LoggerFactory(optionsObj.LoggerFactory);
-
-            _httpClient = optionsObj.HttpClient ?? new HttpClient();
-
             var logger = _loggerFactory?.Create<SinchClient>();
             logger?.LogInformation("Initializing SinchClient...");
+
+
+            if (string.IsNullOrEmpty(projectId))
+            {
+                logger?.LogWarning($"{nameof(projectId)} is not set!");
+            }
+
+            if (string.IsNullOrEmpty(keyId))
+            {
+                logger?.LogWarning($"{nameof(keyId)} is not set!");
+            }
+
+            if (string.IsNullOrEmpty(keySecret))
+            {
+                logger?.LogWarning($"{nameof(keySecret)} is not set!");
+            }
+
+            _httpClient = optionsObj.HttpClient ?? new HttpClient();
 
             _apiUrlOverrides = optionsObj?.ApiUrlOverrides;
 

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -129,6 +129,9 @@ namespace Sinch
         private readonly HttpClient _httpClient;
 
         private readonly ApiUrlOverrides _apiUrlOverrides;
+        private string _keyId;
+        private string _keySecret;
+        private string _projectId;
 
         /// <summary>
         ///     Initialize a new <see cref="SinchClient"/>
@@ -138,22 +141,26 @@ namespace Sinch
         /// <param name="projectId">Your project id.</param>
         /// <param name="options">Optional. See: <see cref="SinchOptions"/></param>
         /// <exception cref="ArgumentNullException"></exception>
-        public SinchClient(string keyId, string keySecret, string projectId,
+        public SinchClient(string projectId, string keyId, string keySecret,
             Action<SinchOptions> options = default)
         {
-            if (keyId is null)
+            _projectId = projectId;
+            _keyId = keyId;
+            if (_keyId is null)
             {
-                throw new ArgumentNullException(nameof(keyId), "Should have a value");
+                throw new ArgumentNullException(nameof(_keyId), "Should have a value");
             }
 
-            if (keySecret is null)
+            _keySecret = keySecret;
+            if (_keySecret is null)
             {
-                throw new ArgumentNullException(nameof(keySecret), "Should have a value");
+                throw new ArgumentNullException(nameof(_keySecret), "Should have a value");
             }
 
-            if (projectId is null)
+            _projectId = projectId;
+            if (_projectId is null)
             {
-                throw new ArgumentNullException(nameof(projectId), "Should have a value");
+                throw new ArgumentNullException(nameof(_projectId), "Should have a value");
             }
 
             var optionsObj = new SinchOptions();
@@ -169,7 +176,7 @@ namespace Sinch
             _apiUrlOverrides = optionsObj?.ApiUrlOverrides;
 
             ISinchAuth auth =
-                new OAuth(keyId, keySecret, _httpClient, _loggerFactory?.Create<OAuth>(),
+                new OAuth(_keyId, _keySecret, _httpClient, _loggerFactory?.Create<OAuth>(),
                     new Uri(_apiUrlOverrides?.AuthUrl ?? AuthApiUrl));
             Auth = auth;
             var httpCamelCase = new Http(auth, _httpClient, _loggerFactory?.Create<Http>(),
@@ -177,12 +184,12 @@ namespace Sinch
             var httpSnakeCase = new Http(auth, _httpClient, _loggerFactory?.Create<Http>(),
                 SnakeCaseNamingPolicy.Instance);
 
-            Numbers = new Numbers.Numbers(projectId, new Uri(_apiUrlOverrides?.NumbersUrl ?? NumbersApiUrl),
+            Numbers = new Numbers.Numbers(_projectId, new Uri(_apiUrlOverrides?.NumbersUrl ?? NumbersApiUrl),
                 _loggerFactory, httpCamelCase);
-            Sms = new Sms(projectId, GetSmsBaseAddress(optionsObj.SmsHostingRegion, _apiUrlOverrides?.SmsUrl),
+            Sms = new Sms(_projectId, GetSmsBaseAddress(optionsObj.SmsHostingRegion, _apiUrlOverrides?.SmsUrl),
                 _loggerFactory,
                 httpSnakeCase);
-            Conversation = new Conversation.SinchConversationClient(projectId,
+            Conversation = new Conversation.SinchConversationClient(_projectId,
                 new Uri(_apiUrlOverrides?.ConversationUrl ??
                         string.Format(ConversationApiUrlTemplate, optionsObj.ConversationRegion.Value)),
                 _loggerFactory, httpSnakeCase);

--- a/tests/Sinch.Tests/SinchClientTests.cs
+++ b/tests/Sinch.Tests/SinchClientTests.cs
@@ -44,23 +44,33 @@ namespace Sinch.Tests
             var conversationOp = () => sinch.Conversation;
             var aggregateExceptionConversation = conversationOp.Should().Throw<AggregateException>().Which;
             aggregateExceptionConversation.Message.Should().BeEquivalentTo(message);
-            
+
             var numbersOp = () => sinch.Numbers;
             var aggregateExceptionNumbers = numbersOp.Should().Throw<AggregateException>().Which;
             aggregateExceptionNumbers.Message.Should().BeEquivalentTo(message);
-            
+
             var authOp = () => sinch.Auth;
             var aggregateExceptionAuth = authOp.Should().Throw<AggregateException>().Which;
             aggregateExceptionAuth.Message.Should().BeEquivalentTo(message);
         }
-        
+
+        [Fact]
+        public void GetServiceWithoutExceptionsIfCredentialsAreSet()
+        {
+            var sinch = new SinchClient("projectId", "keyId", "keySecret");
+            sinch.Conversation.Should().NotBeNull();
+            sinch.Sms.Should().NotBeNull();
+            sinch.Auth.Should().NotBeNull();
+            sinch.Numbers.Should().NotBeNull();
+        }
+
         [Fact]
         public void InitializeOwnHttpIfNotPassed()
         {
             var sinch = new SinchClient("proj", "id", "secret");
             Helpers.GetPrivateField<HttpClient, SinchClient>(sinch, "_httpClient").Should().NotBeNull();
         }
-        
+
         [Fact]
         public void InitSinchClientWithCustomHttpClient()
         {

--- a/tests/Sinch.Tests/SinchClientTests.cs
+++ b/tests/Sinch.Tests/SinchClientTests.cs
@@ -7,42 +7,18 @@ namespace Sinch.Tests
 {
     public class SinchClientTests
     {
-        [Fact]
-        public void InitSinchClientWithoutAllCredentials()
+        [Theory]
+        [InlineData(null, null, null)]
+        [InlineData("projectId", null, null)]
+        [InlineData(null, "keyId", null)]
+        [InlineData(null, null, "keySecret")]
+        [InlineData("projectId", "keySecret", null)]
+        [InlineData("projectId", null, "keySecret")]
+        [InlineData(null, "keySecret", "keySecret")]
+        public void InitSinchClientWithoutCredentials(string projectId, string keyId, string keySecret)
         {
-            var sinch = new SinchClient(null, null, null);
+            var sinch = new SinchClient(projectId, keyId, keySecret);
             sinch.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void InitSinchClientWithoutProjectId()
-        {
-            var sinch = new SinchClient(null, "key", "secret");
-            sinch.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void InitSinchClientWithoutKeyId()
-        {
-            var sinch = new SinchClient("key", null, "secret");
-            sinch.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void InitSinchClientWithoutKeySecret()
-        {
-            var sinch = new SinchClient("key", "secret", null);
-            sinch.Should().NotBeNull();
-        }
-
-        [Fact]
-        public void InitSinchClientWithCustomHttpClient()
-        {
-            var httpClient = new HttpClient();
-            var sinch = new SinchClient("TEST_PROJECT_ID", "TEST_KEY", "TEST_KEY_SECRET",
-                options => { options.HttpClient = httpClient; });
-            sinch.Should().NotBeNull();
-            Helpers.GetPrivateField<HttpClient, SinchClient>(sinch, "_httpClient").Should().Be(httpClient);
         }
 
         [Theory]
@@ -77,11 +53,22 @@ namespace Sinch.Tests
             var aggregateExceptionAuth = authOp.Should().Throw<AggregateException>().Which;
             aggregateExceptionAuth.Message.Should().BeEquivalentTo(message);
         }
+        
         [Fact]
         public void InitializeOwnHttpIfNotPassed()
         {
             var sinch = new SinchClient("proj", "id", "secret");
             Helpers.GetPrivateField<HttpClient, SinchClient>(sinch, "_httpClient").Should().NotBeNull();
+        }
+        
+        [Fact]
+        public void InitSinchClientWithCustomHttpClient()
+        {
+            var httpClient = new HttpClient();
+            var sinch = new SinchClient("TEST_PROJECT_ID", "TEST_KEY", "TEST_KEY_SECRET",
+                options => { options.HttpClient = httpClient; });
+            sinch.Should().NotBeNull();
+            Helpers.GetPrivateField<HttpClient, SinchClient>(sinch, "_httpClient").Should().Be(httpClient);
         }
     }
 }

--- a/tests/Sinch.Tests/SinchClientTests.cs
+++ b/tests/Sinch.Tests/SinchClientTests.cs
@@ -10,7 +10,7 @@ namespace Sinch.Tests
         [Fact]
         public void Should_instantiate_sinch_client_with_provided_required_params()
         {
-            var sinch = new SinchClient("TEST_KEY", "TEST_KEY_SECRET", "TEST_PROJECT_ID");
+            var sinch = new SinchClient("TEST_PROJECT_ID", "TEST_KEY", "TEST_KEY_SECRET");
             sinch.Should().NotBeNull();
             sinch.Numbers.Should().NotBeNull();
         }
@@ -19,7 +19,7 @@ namespace Sinch.Tests
         public void InitSinchClientWithCustomHttpClient()
         {
             var httpClient = new HttpClient();
-            var sinch = new SinchClient("TEST_KEY", "TEST_KEY_SECRET", "TEST_PROJECT_ID",
+            var sinch = new SinchClient("TEST_PROJECT_ID", "TEST_KEY", "TEST_KEY_SECRET",
                 options => { options.HttpClient = httpClient; });
             sinch.Should().NotBeNull();
             Helpers.GetPrivateField<HttpClient, SinchClient>(sinch, "_httpClient").Should().Be(httpClient);
@@ -28,28 +28,28 @@ namespace Sinch.Tests
         [Fact]
         public void ThrowNullKeyId()
         {
-            Func<ISinchClient> initAction = () => new SinchClient(null, "secret", "project");
+            Func<ISinchClient> initAction = () => new SinchClient("project", null, "secret");
             initAction.Should().Throw<ArgumentNullException>("Should have a value");
         }
 
         [Fact]
         public void ThrowNullKeySecret()
         {
-            Func<ISinchClient> initAction = () => new SinchClient("secret", null, "project");
+            Func<ISinchClient> initAction = () => new SinchClient("project", "secret", null);
             initAction.Should().Throw<ArgumentNullException>("Should have a value");
         }
 
         [Fact]
         public void ThrowNullProjectId()
         {
-            Func<ISinchClient> initAction = () => new SinchClient("id", "secret", null);
+            Func<ISinchClient> initAction = () => new SinchClient(null, "id", "secret");
             initAction.Should().Throw<ArgumentNullException>("Should have a value");
         }
 
         [Fact]
         public void InitializeOwnHttpIfNotPassed()
         {
-            var sinch = new SinchClient("id", "secret", "proj");
+            var sinch = new SinchClient("proj", "id", "secret");
             Helpers.GetPrivateField<HttpClient, SinchClient>(sinch, "_httpClient").Should().NotBeNull();
         }
     }

--- a/tests/Sinch.Tests/e2e/TestBase.cs
+++ b/tests/Sinch.Tests/e2e/TestBase.cs
@@ -18,7 +18,7 @@ namespace Sinch.Tests.e2e
         protected TestBase()
         {
             Env.Load();
-            SinchClientMockStudio = new SinchClient("key_id", "key_secret", ProjectId,
+            SinchClientMockStudio = new SinchClient(ProjectId, "key_id", "key_secret",
                 options =>
                 {
                     options.ApiUrlOverrides = new ApiUrlOverrides()
@@ -29,7 +29,7 @@ namespace Sinch.Tests.e2e
                     };
                 });
 
-            SinchClientMockServer = new SinchClient("key_id", "key_secret", ProjectId, options =>
+            SinchClientMockServer = new SinchClient(ProjectId, "key_id", "key_secret", options =>
             {
                 options.ApiUrlOverrides = new ApiUrlOverrides()
                 {


### PR DESCRIPTION
Move `projectId` to first place as a param. 
Allow initialization of sinchClient  Voice or Verification without settings params projectId, keyid and keysecret.
I would like to still have just one constructor for SinchClient to make an accent on unified credentials.
Add example on how to init Voice or Verification client
When accessing products  which relies on unified credentials - Sms, Numbers, Conversation, Auth - without providing them , an aggregate exception will be thrown.