### PR TITLE
Feat: add br region to conversation, extract and test url resolutions

### DIFF
--- a/src/Sinch/Conversation/ConversationRegion.cs
+++ b/src/Sinch/Conversation/ConversationRegion.cs
@@ -5,8 +5,19 @@ namespace Sinch.Conversation
     /// </summary>
     public record ConversationRegion(string Value)
     {
+        /// <summary>
+        ///     US Production
+        /// </summary>
         public static readonly ConversationRegion Us = new("us");
 
+        /// <summary>
+        ///     EU Production
+        /// </summary>
         public static readonly ConversationRegion Eu = new("eu");
+
+        /// <summary>
+        ///     BR Production
+        /// </summary>
+        public static readonly ConversationRegion Br = new("br");
     }
 }

--- a/src/Sinch/Core/UrlResolver.cs
+++ b/src/Sinch/Core/UrlResolver.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using Sinch.Conversation;
+using Sinch.Voice;
 
 namespace Sinch.Core
 {
     internal static class UrlResolver
     {
         private const string ConversationApiUrlTemplate = "https://{0}.conversation.api.sinch.com/";
-        private const string TemplatesApiUrlTemplate = "https://{0}.template.api.sinch.com/";
 
         public static Uri ResolveConversationUrl(ConversationRegion conversationRegion,
             ApiUrlOverrides? apiUrlOverrides)
@@ -16,12 +16,36 @@ namespace Sinch.Core
                                conversationRegion.Value));
         }
 
+        private const string TemplatesApiUrlTemplate = "https://{0}.template.api.sinch.com/";
+
         public static Uri ResolveTemplateUrl(ConversationRegion conversationRegion,
             ApiUrlOverrides? apiUrlOverrides)
         {
             return new Uri(apiUrlOverrides?.TemplatesUrl ??
                            string.Format(TemplatesApiUrlTemplate,
                                conversationRegion.Value));
+        }
+
+        private const string AuthApiUrl = "https://auth.sinch.com";
+
+        public static Uri ResolveAuthApiUrl(ApiUrlOverrides? apiUrlOverrides)
+        {
+            return new Uri(apiUrlOverrides?.AuthUrl ?? AuthApiUrl);
+        }
+
+        private const string VoiceApiUrlTemplate = "https://{0}.api.sinch.com/";
+
+        public static Uri ResolveVoiceApiUrl(VoiceRegion voiceRegion, ApiUrlOverrides? apiUrlOverrides)
+        {
+            return new Uri(apiUrlOverrides?.VoiceUrl ?? string.Format(VoiceApiUrlTemplate, voiceRegion.Value));
+        }
+
+        // apparently, management api for applications have a different set url
+        private const string VoiceApiApplicationManagementUrl = "https://callingapi.sinch.com/";
+
+        public static Uri ResolveVoiceApiApplicationManagementUrl(ApiUrlOverrides? apiUrlOverrides)
+        {
+            return new Uri(apiUrlOverrides?.VoiceApplicationManagementUrl ?? VoiceApiApplicationManagementUrl);
         }
     }
 }

--- a/src/Sinch/Core/UrlResolver.cs
+++ b/src/Sinch/Core/UrlResolver.cs
@@ -1,51 +1,95 @@
-﻿using System;
+using System;
 using Sinch.Conversation;
+using Sinch.SMS;
 using Sinch.Voice;
 
 namespace Sinch.Core
 {
-    internal static class UrlResolver
+    internal class UrlResolver
     {
+        private readonly ApiUrlOverrides? _apiUrlOverrides;
+
+        public UrlResolver(ApiUrlOverrides? apiUrlOverrides)
+        {
+            _apiUrlOverrides = apiUrlOverrides;
+        }
+
         private const string ConversationApiUrlTemplate = "https://{0}.conversation.api.sinch.com/";
 
-        public static Uri ResolveConversationUrl(ConversationRegion conversationRegion,
-            ApiUrlOverrides? apiUrlOverrides)
+        public Uri ResolveConversationUrl(ConversationRegion conversationRegion)
         {
-            return new Uri(apiUrlOverrides?.ConversationUrl ??
+            return new Uri(_apiUrlOverrides?.ConversationUrl ??
                            string.Format(ConversationApiUrlTemplate,
                                conversationRegion.Value));
         }
 
         private const string TemplatesApiUrlTemplate = "https://{0}.template.api.sinch.com/";
 
-        public static Uri ResolveTemplateUrl(ConversationRegion conversationRegion,
-            ApiUrlOverrides? apiUrlOverrides)
+        public Uri ResolveTemplateUrl(ConversationRegion conversationRegion)
         {
-            return new Uri(apiUrlOverrides?.TemplatesUrl ??
+            return new Uri(_apiUrlOverrides?.TemplatesUrl ??
                            string.Format(TemplatesApiUrlTemplate,
                                conversationRegion.Value));
         }
 
         private const string AuthApiUrl = "https://auth.sinch.com";
 
-        public static Uri ResolveAuthApiUrl(ApiUrlOverrides? apiUrlOverrides)
+        public Uri ResolveAuthApiUrl()
         {
-            return new Uri(apiUrlOverrides?.AuthUrl ?? AuthApiUrl);
+            return new Uri(_apiUrlOverrides?.AuthUrl ?? AuthApiUrl);
         }
 
         private const string VoiceApiUrlTemplate = "https://{0}.api.sinch.com/";
 
-        public static Uri ResolveVoiceApiUrl(VoiceRegion voiceRegion, ApiUrlOverrides? apiUrlOverrides)
+        public Uri ResolveVoiceApiUrl(VoiceRegion voiceRegion)
         {
-            return new Uri(apiUrlOverrides?.VoiceUrl ?? string.Format(VoiceApiUrlTemplate, voiceRegion.Value));
+            return new Uri(_apiUrlOverrides?.VoiceUrl ?? string.Format(VoiceApiUrlTemplate, voiceRegion.Value));
         }
 
         // apparently, management api for applications have a different set url
         private const string VoiceApiApplicationManagementUrl = "https://callingapi.sinch.com/";
 
-        public static Uri ResolveVoiceApiApplicationManagementUrl(ApiUrlOverrides? apiUrlOverrides)
+        public Uri ResolveVoiceApiApplicationManagementUrl()
         {
-            return new Uri(apiUrlOverrides?.VoiceApplicationManagementUrl ?? VoiceApiApplicationManagementUrl);
+            return new Uri(_apiUrlOverrides?.VoiceApplicationManagementUrl ?? VoiceApiApplicationManagementUrl);
+        }
+
+        private const string VerificationApiUrl = "https://verification.api.sinch.com/";
+
+        public Uri ResolveVerificationUrl()
+        {
+            return new Uri(_apiUrlOverrides?.VerificationUrl ?? VerificationApiUrl);
+        }
+
+        private const string NumbersApiUrl = "https://numbers.api.sinch.com/";
+
+        public Uri ResolveNumbersUrl()
+        {
+            return new Uri(_apiUrlOverrides?.NumbersUrl ?? NumbersApiUrl);
+        }
+
+        private const string SmsApiUrlTemplate = "https://zt.{0}.sms.api.sinch.com";
+
+        public Uri ResolveSmsUrl(SmsRegion smsRegion)
+        {
+            // ReSharper disable once ConvertIfStatementToReturnStatement
+            if (!string.IsNullOrEmpty(_apiUrlOverrides?.SmsUrl)) return new Uri(_apiUrlOverrides.SmsUrl);
+
+            // General SMS rest api uses service_plan_id to performs calls
+            // But SDK is based on single-account model which uses project_id
+            // Thus, baseAddress for sms api is using a special endpoint where service_plan_id is replaced with projectId
+            // for each provided endpoint
+            return new Uri(string.Format(SmsApiUrlTemplate, smsRegion.Value));
+        }
+
+        private const string SmsApiServicePlanIdUrlTemplate = "https://{0}.sms.api.sinch.com";
+
+        public Uri ResolveSmsServicePlanIdUrl(SmsServicePlanIdRegion smsServicePlanIdRegion)
+        {
+            if (!string.IsNullOrEmpty(_apiUrlOverrides?.SmsUrl)) return new Uri(_apiUrlOverrides.SmsUrl);
+
+            return new Uri(string.Format(SmsApiServicePlanIdUrlTemplate,
+                smsServicePlanIdRegion.Value.ToLowerInvariant()));
         }
     }
 }

--- a/src/Sinch/Core/UrlResolver.cs
+++ b/src/Sinch/Core/UrlResolver.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Sinch.Conversation;
+
+namespace Sinch.Core
+{
+    internal static class UrlResolver
+    {
+        private const string ConversationApiUrlTemplate = "https://{0}.conversation.api.sinch.com/";
+        private const string TemplatesApiUrlTemplate = "https://{0}.template.api.sinch.com/";
+
+        public static Uri ResolveConversationUrl(ConversationRegion conversationRegion,
+            ApiUrlOverrides? apiUrlOverrides)
+        {
+            return new Uri(apiUrlOverrides?.ConversationUrl ??
+                           string.Format(ConversationApiUrlTemplate,
+                               conversationRegion.Value));
+        }
+
+        public static Uri ResolveTemplateUrl(ConversationRegion conversationRegion,
+            ApiUrlOverrides? apiUrlOverrides)
+        {
+            return new Uri(apiUrlOverrides?.TemplatesUrl ??
+                           string.Format(TemplatesApiUrlTemplate,
+                               conversationRegion.Value));
+        }
+    }
+}

--- a/src/Sinch/SMS/SmsRegion.cs
+++ b/src/Sinch/SMS/SmsRegion.cs
@@ -8,11 +8,11 @@ namespace Sinch.SMS
         /// <summary>
         ///     USA
         /// </summary>
-        public static readonly SmsRegion Us = new("Us");
+        public static readonly SmsRegion Us = new("us");
 
         /// <summary>
         ///     Ireland, Sweden
         /// </summary>
-        public static readonly SmsRegion Eu = new("Eu");
+        public static readonly SmsRegion Eu = new("eu");
     }
 }

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -115,12 +115,6 @@ namespace Sinch
 
     public class SinchClient : ISinchClient
     {
-        private const string VerificationApiUrl = "https://verification.api.sinch.com/";
-        private const string NumbersApiUrl = "https://numbers.api.sinch.com/";
-        private const string SmsApiUrlTemplate = "https://zt.{0}.sms.api.sinch.com";
-        private const string SmsApiServicePlanIdUrlTemplate = "https://{0}.sms.api.sinch.com";
-
-
         private readonly ApiUrlOverrides? _apiUrlOverrides;
         private readonly ISinchAuth _auth;
         private readonly ISinchConversation _conversation;
@@ -136,6 +130,8 @@ namespace Sinch
 
         private readonly ISinchSms _sms;
         private readonly ILoggerAdapter<ISinchClient>? _logger;
+        private readonly UrlResolver _urlResolver;
+
 
         /// <summary>
         ///     Initialize a new <see cref="SinchClient" />
@@ -169,25 +165,26 @@ namespace Sinch
             _httpClient = optionsObj.HttpClient ?? new HttpClient();
 
             _apiUrlOverrides = optionsObj.ApiUrlOverrides;
+            _urlResolver = new UrlResolver(_apiUrlOverrides);
 
             ISinchAuth auth =
                 // exception is throw when trying to get OAuth or Oauth dependant clients if credentials are missing
                 new OAuth(_keyId!, _keySecret!, _httpClient, _loggerFactory?.Create<OAuth>(),
-                    UrlResolver.ResolveAuthApiUrl(_apiUrlOverrides));
+                    _urlResolver.ResolveAuthApiUrl());
             _auth = auth;
             var httpCamelCase = new Http(auth, _httpClient, _loggerFactory?.Create<IHttp>(),
                 JsonNamingPolicy.CamelCase);
             var httpSnakeCaseOAuth = new Http(auth, _httpClient, _loggerFactory?.Create<IHttp>(),
                 SnakeCaseNamingPolicy.Instance);
 
-            _numbers = new Numbers.Numbers(_projectId!, new Uri(_apiUrlOverrides?.NumbersUrl ?? NumbersApiUrl),
+            _numbers = new Numbers.Numbers(_projectId!, _urlResolver.ResolveNumbersUrl(),
                 _loggerFactory, httpCamelCase);
 
             _sms = InitSms(optionsObj, httpSnakeCaseOAuth);
 
             var conversationBaseAddress =
-                UrlResolver.ResolveConversationUrl(optionsObj.ConversationRegion, _apiUrlOverrides);
-            var templatesBaseAddress = UrlResolver.ResolveTemplateUrl(optionsObj.ConversationRegion, _apiUrlOverrides);
+                _urlResolver.ResolveConversationUrl(optionsObj.ConversationRegion);
+            var templatesBaseAddress = _urlResolver.ResolveTemplateUrl(optionsObj.ConversationRegion);
             _conversation = new SinchConversationClient(_projectId!, conversationBaseAddress
                 , templatesBaseAddress,
                 _loggerFactory, httpSnakeCaseOAuth);
@@ -254,7 +251,7 @@ namespace Sinch
                 auth = new BasicAuth(appKey, appSecret);
 
             var http = new Http(auth, _httpClient, _loggerFactory?.Create<IHttp>(), JsonNamingPolicy.CamelCase);
-            return new SinchVerificationClient(new Uri(_apiUrlOverrides?.VerificationUrl ?? VerificationApiUrl),
+            return new SinchVerificationClient(_urlResolver.ResolveVerificationUrl(),
                 _loggerFactory, http);
         }
 
@@ -274,9 +271,9 @@ namespace Sinch
 
             var http = new Http(auth, _httpClient, _loggerFactory?.Create<IHttp>(), JsonNamingPolicy.CamelCase);
             return new SinchVoiceClient(
-                UrlResolver.ResolveVoiceApiUrl(voiceRegion, _apiUrlOverrides),
+                _urlResolver.ResolveVoiceApiUrl(voiceRegion),
                 _loggerFactory, http, (auth as ApplicationSignedAuth)!,
-                UrlResolver.ResolveVoiceApiApplicationManagementUrl(_apiUrlOverrides));
+                _urlResolver.ResolveVoiceApiApplicationManagementUrl());
         }
 
         private void ValidateCommonCredentials()
@@ -305,8 +302,7 @@ namespace Sinch
                     _loggerFactory?.Create<IHttp>(),
                     SnakeCaseNamingPolicy.Instance);
                 return new SmsClient(new ServicePlanId(optionsObj.ServicePlanIdOptions.ServicePlanId),
-                    BuildServicePlanIdSmsBaseAddress(optionsObj.ServicePlanIdOptions.Region,
-                        _apiUrlOverrides?.SmsUrl),
+                    _urlResolver.ResolveSmsServicePlanIdUrl(optionsObj.ServicePlanIdOptions.Region),
                     _loggerFactory, bearerSnakeHttp);
             }
 
@@ -316,29 +312,9 @@ namespace Sinch
             return new SmsClient(
                 new ProjectId(
                     _projectId!), // exception is throw when trying to get SMS client property if _projectId is null
-                BuildSmsBaseAddress(optionsObj.SmsRegion, _apiUrlOverrides?.SmsUrl),
+                _urlResolver.ResolveSmsUrl(optionsObj.SmsRegion),
                 _loggerFactory,
                 httpSnakeCase);
-        }
-
-        private static Uri BuildServicePlanIdSmsBaseAddress(SmsServicePlanIdRegion smsServicePlanIdRegion,
-            string? smsUrlOverride)
-        {
-            if (!string.IsNullOrEmpty(smsUrlOverride)) return new Uri(smsUrlOverride);
-
-            return new Uri(string.Format(SmsApiServicePlanIdUrlTemplate,
-                smsServicePlanIdRegion.Value.ToLowerInvariant()));
-        }
-
-        private static Uri BuildSmsBaseAddress(SmsRegion smsRegion, string? smsUrlOverride)
-        {
-            if (!string.IsNullOrEmpty(smsUrlOverride)) return new Uri(smsUrlOverride);
-
-            // General SMS rest api uses service_plan_id to performs calls
-            // But SDK is based on single-account model which uses project_id
-            // Thus, baseAddress for sms api is using a special endpoint where service_plan_id is replaced with projectId
-            // for each provided endpoint
-            return new Uri(string.Format(SmsApiUrlTemplate, smsRegion.Value.ToLowerInvariant()));
         }
     }
 }

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -119,14 +119,13 @@ namespace Sinch
         private const string NumbersApiUrl = "https://numbers.api.sinch.com/";
         private const string SmsApiUrlTemplate = "https://zt.{0}.sms.api.sinch.com";
         private const string SmsApiServicePlanIdUrlTemplate = "https://{0}.sms.api.sinch.com";
-        private const string ConversationApiUrlTemplate = "https://{0}.conversation.api.sinch.com/";
 
         private const string VoiceApiUrlTemplate = "https://{0}.api.sinch.com/";
 
         // apparently, management api for applications have a different set url
         private const string VoiceApiApplicationManagementUrl = "https://callingapi.sinch.com/";
         private const string AuthApiUrl = "https://auth.sinch.com";
-        private const string TemplatesApiUrlTemplate = "https://{0}.template.api.sinch.com/";
+
 
         private readonly ApiUrlOverrides? _apiUrlOverrides;
         private readonly ISinchAuth _auth;
@@ -192,12 +191,9 @@ namespace Sinch
 
             _sms = InitSms(optionsObj, httpSnakeCaseOAuth);
 
-            var conversationBaseAddress = new Uri(_apiUrlOverrides?.ConversationUrl ??
-                                                  string.Format(ConversationApiUrlTemplate,
-                                                      optionsObj.ConversationRegion.Value));
-            var templatesBaseAddress = new Uri(_apiUrlOverrides?.TemplatesUrl ??
-                                               string.Format(TemplatesApiUrlTemplate,
-                                                   optionsObj.ConversationRegion.Value));
+            var conversationBaseAddress =
+                UrlResolver.ResolveConversationUrl(optionsObj.ConversationRegion, _apiUrlOverrides);
+            var templatesBaseAddress = UrlResolver.ResolveTemplateUrl(optionsObj.ConversationRegion, _apiUrlOverrides);
             _conversation = new SinchConversationClient(_projectId!, conversationBaseAddress
                 , templatesBaseAddress,
                 _loggerFactory, httpSnakeCaseOAuth);

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -120,12 +120,6 @@ namespace Sinch
         private const string SmsApiUrlTemplate = "https://zt.{0}.sms.api.sinch.com";
         private const string SmsApiServicePlanIdUrlTemplate = "https://{0}.sms.api.sinch.com";
 
-        private const string VoiceApiUrlTemplate = "https://{0}.api.sinch.com/";
-
-        // apparently, management api for applications have a different set url
-        private const string VoiceApiApplicationManagementUrl = "https://callingapi.sinch.com/";
-        private const string AuthApiUrl = "https://auth.sinch.com";
-
 
         private readonly ApiUrlOverrides? _apiUrlOverrides;
         private readonly ISinchAuth _auth;
@@ -179,7 +173,7 @@ namespace Sinch
             ISinchAuth auth =
                 // exception is throw when trying to get OAuth or Oauth dependant clients if credentials are missing
                 new OAuth(_keyId!, _keySecret!, _httpClient, _loggerFactory?.Create<OAuth>(),
-                    new Uri(_apiUrlOverrides?.AuthUrl ?? AuthApiUrl));
+                    UrlResolver.ResolveAuthApiUrl(_apiUrlOverrides));
             _auth = auth;
             var httpCamelCase = new Http(auth, _httpClient, _loggerFactory?.Create<IHttp>(),
                 JsonNamingPolicy.CamelCase);
@@ -280,9 +274,9 @@ namespace Sinch
 
             var http = new Http(auth, _httpClient, _loggerFactory?.Create<IHttp>(), JsonNamingPolicy.CamelCase);
             return new SinchVoiceClient(
-                new Uri(_apiUrlOverrides?.VoiceUrl ?? string.Format(VoiceApiUrlTemplate, voiceRegion.Value)),
+                UrlResolver.ResolveVoiceApiUrl(voiceRegion, _apiUrlOverrides),
                 _loggerFactory, http, (auth as ApplicationSignedAuth)!,
-                new Uri(_apiUrlOverrides?.VoiceUrl ?? VoiceApiApplicationManagementUrl));
+                UrlResolver.ResolveVoiceApiApplicationManagementUrl(_apiUrlOverrides));
         }
 
         private void ValidateCommonCredentials()

--- a/src/Sinch/SinchOptions.cs
+++ b/src/Sinch/SinchOptions.cs
@@ -108,7 +108,7 @@ namespace Sinch
 
         /// <summary>
         ///     Overrides Templates api base url.
-        ///     Templates is treated as part of conversation api, but it has another base address.
+        ///     Templates are treated as part of conversation api, but it has another base address.
         /// </summary>
         public string? TemplatesUrl { get; init; }
 
@@ -116,6 +116,11 @@ namespace Sinch
         ///     Overrides Voice api base url
         /// </summary>
         public string? VoiceUrl { get; init; }
+
+        /// <summary>
+        ///     Overrides Voice api application management base url
+        /// </summary>
+        public string? VoiceApplicationManagementUrl { get; init; }
 
         /// <summary>
         ///     Overrides Verification api base url

--- a/tests/Sinch.Tests/Core/UrlResolverTests.cs
+++ b/tests/Sinch.Tests/Core/UrlResolverTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using Sinch.Conversation;
 using Sinch.Core;
+using Sinch.SMS;
 using Sinch.Voice;
 using Xunit;
 
@@ -35,7 +36,7 @@ namespace Sinch.Tests.Core
         [MemberData(nameof(ConversationUrlResolveData))]
         public void ResolveConversationUrl(ConversationRegion region, ApiUrlOverrides apiUrlOverrides)
         {
-            var conversationUrl = UrlResolver.ResolveConversationUrl(region, apiUrlOverrides);
+            var conversationUrl = new UrlResolver(apiUrlOverrides).ResolveConversationUrl(region);
             var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.ConversationUrl)
                 ? new Uri($"https://{region.Value}.conversation.api.sinch.com/")
                 : new Uri(apiUrlOverrides.ConversationUrl);
@@ -61,7 +62,7 @@ namespace Sinch.Tests.Core
         [MemberData(nameof(AuthUrlResolveData))]
         public void ResolveAuthUrl(ApiUrlOverrides apiUrlOverrides)
         {
-            var authUrl = UrlResolver.ResolveAuthApiUrl(apiUrlOverrides);
+            var authUrl = new UrlResolver(apiUrlOverrides).ResolveAuthApiUrl();
             var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.AuthUrl)
                 ? new Uri("https://auth.sinch.com")
                 : new Uri(apiUrlOverrides.AuthUrl);
@@ -116,7 +117,7 @@ namespace Sinch.Tests.Core
         [MemberData(nameof(VoiceUrlResolveData))]
         public void ResolveVoiceUrl(VoiceRegion voiceRegion, ApiUrlOverrides apiUrlOverrides)
         {
-            var voiceUrl = UrlResolver.ResolveVoiceApiUrl(voiceRegion, apiUrlOverrides);
+            var voiceUrl = new UrlResolver(apiUrlOverrides).ResolveVoiceApiUrl(voiceRegion);
             var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.VoiceUrl)
                 ? new Uri($"https://{voiceRegion.Value}.api.sinch.com/")
                 : new Uri(apiUrlOverrides.VoiceUrl);
@@ -149,11 +150,169 @@ namespace Sinch.Tests.Core
         [MemberData(nameof(VoiceApplicationManagementData))]
         public void ResolveVoiceApplicationManagementUrl(ApiUrlOverrides apiUrlOverrides)
         {
-            var voiceUrl = UrlResolver.ResolveVoiceApiApplicationManagementUrl(apiUrlOverrides);
+            var voiceUrl = new UrlResolver(apiUrlOverrides).ResolveVoiceApiApplicationManagementUrl();
             var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.VoiceApplicationManagementUrl)
                 ? new Uri($"https://callingapi.sinch.com/")
                 : new Uri(apiUrlOverrides.VoiceApplicationManagementUrl);
             voiceUrl.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        public static IEnumerable<object[]> VerificationUrlData => new List<object[]>
+        {
+            new object[]
+            {
+                null
+            },
+            new object[]
+            {
+                new ApiUrlOverrides()
+                {
+                    VerificationUrl = null
+                }
+            },
+            new object[]
+            {
+                new ApiUrlOverrides()
+                {
+                    VerificationUrl = "https://hello.world"
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(VerificationUrlData))]
+        public void ResolveVerificationUrl(ApiUrlOverrides apiUrlOverrides)
+        {
+            var verificationUrl = new UrlResolver(apiUrlOverrides).ResolveVerificationUrl();
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.VerificationUrl)
+                ? new Uri($"https://verification.api.sinch.com/")
+                : new Uri(apiUrlOverrides.VerificationUrl);
+            verificationUrl.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        public static IEnumerable<object[]> NumbersUrlData => new List<object[]>
+        {
+            new object[]
+            {
+                null
+            },
+            new object[]
+            {
+                new ApiUrlOverrides()
+                {
+                    NumbersUrl = null
+                }
+            },
+            new object[]
+            {
+                new ApiUrlOverrides()
+                {
+                    NumbersUrl = "https://hello.world"
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(NumbersUrlData))]
+        public void ResolveNumbersUrl(ApiUrlOverrides apiUrlOverrides)
+        {
+            var verificationUrl = new UrlResolver(apiUrlOverrides).ResolveNumbersUrl();
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.NumbersUrl)
+                ? new Uri("https://numbers.api.sinch.com/")
+                : new Uri(apiUrlOverrides.NumbersUrl);
+            verificationUrl.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        public static IEnumerable<object[]> SmsUrlData => new List<object[]>
+        {
+            new object[]
+            {
+                SmsRegion.Eu,
+                null,
+            },
+            new object[]
+            {
+                SmsRegion.Us,
+                new ApiUrlOverrides()
+                {
+                    SmsUrl = null
+                }
+            },
+            new object[]
+            {
+                SmsRegion.Eu,
+                new ApiUrlOverrides()
+                {
+                    SmsUrl = "https://hello.world"
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(SmsUrlData))]
+        public void ResolveSmsUrl(SmsRegion smsRegion, ApiUrlOverrides apiUrlOverrides)
+        {
+            var smsUrl = new UrlResolver(apiUrlOverrides).ResolveSmsUrl(smsRegion);
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.SmsUrl)
+                ? new Uri($"https://zt.{smsRegion.Value}.sms.api.sinch.com/")
+                : new Uri(apiUrlOverrides.SmsUrl);
+            smsUrl.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        public static IEnumerable<object[]> SmsServicePlanIdUrlData => new List<object[]>
+        {
+            new object[]
+            {
+                SmsServicePlanIdRegion.Us,
+                null,
+            },
+            new object[]
+            {
+                SmsServicePlanIdRegion.Eu,
+                null,
+            },
+            new object[]
+            {
+                SmsServicePlanIdRegion.Au,
+                null,
+            },
+            new object[]
+            {
+                SmsServicePlanIdRegion.Br,
+                null,
+            },
+            new object[]
+            {
+                SmsServicePlanIdRegion.Ca,
+                null,
+            },
+            new object[]
+            {
+                SmsServicePlanIdRegion.Us,
+                new ApiUrlOverrides()
+                {
+                    SmsUrl = null
+                }
+            },
+            new object[]
+            {
+                SmsServicePlanIdRegion.Eu,
+                new ApiUrlOverrides()
+                {
+                    SmsUrl = "https://hello.world"
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(SmsServicePlanIdUrlData))]
+        public void ResolveSmsServicePlanIdUrl(SmsServicePlanIdRegion smsServicePlanIdRegion, ApiUrlOverrides apiUrlOverrides)
+        {
+            var smsUrl = new UrlResolver(apiUrlOverrides).ResolveSmsServicePlanIdUrl(smsServicePlanIdRegion);
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.SmsUrl)
+                ? new Uri($"https://{smsServicePlanIdRegion.Value}.sms.api.sinch.com/")
+                : new Uri(apiUrlOverrides.SmsUrl);
+            smsUrl.Should().BeEquivalentTo(expectedUrl);
         }
     }
 }

--- a/tests/Sinch.Tests/Core/UrlResolverTests.cs
+++ b/tests/Sinch.Tests/Core/UrlResolverTests.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using FluentAssertions;
 using Sinch.Conversation;
 using Sinch.Core;
+using Sinch.Voice;
 using Xunit;
 
 namespace Sinch.Tests.Core
@@ -35,11 +35,125 @@ namespace Sinch.Tests.Core
         [MemberData(nameof(ConversationUrlResolveData))]
         public void ResolveConversationUrl(ConversationRegion region, ApiUrlOverrides apiUrlOverrides)
         {
-            var url = UrlResolver.ResolveConversationUrl(region, apiUrlOverrides);
+            var conversationUrl = UrlResolver.ResolveConversationUrl(region, apiUrlOverrides);
             var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.ConversationUrl)
                 ? new Uri($"https://{region.Value}.conversation.api.sinch.com/")
                 : new Uri(apiUrlOverrides.ConversationUrl);
-            url.Should().BeEquivalentTo(expectedUrl);
+            conversationUrl.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        public static IEnumerable<object[]> AuthUrlResolveData => new List<object[]>
+        {
+            new object[]
+            {
+                null
+            },
+            new object[]
+            {
+                new ApiUrlOverrides()
+                {
+                    AuthUrl = null
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(AuthUrlResolveData))]
+        public void ResolveAuthUrl(ApiUrlOverrides apiUrlOverrides)
+        {
+            var authUrl = UrlResolver.ResolveAuthApiUrl(apiUrlOverrides);
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.AuthUrl)
+                ? new Uri("https://auth.sinch.com")
+                : new Uri(apiUrlOverrides.AuthUrl);
+            authUrl.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        public static IEnumerable<object[]> VoiceUrlResolveData => new List<object[]>
+        {
+            new object[]
+            {
+                VoiceRegion.Global, null
+            },
+            new object[]
+            {
+                VoiceRegion.Europe, null
+            },
+            new object[]
+            {
+                VoiceRegion.NorthAmerica, null
+            },
+            new object[]
+            {
+                VoiceRegion.SouthAmerica, null
+            },
+            new object[]
+            {
+                VoiceRegion.SouthEastAsia2, null
+            },
+            new object[]
+            {
+                VoiceRegion.SouthEastAsia1, null
+            },
+            new object[]
+            {
+                VoiceRegion.SouthEastAsia1,
+                new ApiUrlOverrides()
+                {
+                    VoiceUrl = null
+                }
+            },
+            new object[]
+            {
+                VoiceRegion.SouthEastAsia1,
+                new ApiUrlOverrides()
+                {
+                    VoiceUrl = "https://hello.world"
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(VoiceUrlResolveData))]
+        public void ResolveVoiceUrl(VoiceRegion voiceRegion, ApiUrlOverrides apiUrlOverrides)
+        {
+            var voiceUrl = UrlResolver.ResolveVoiceApiUrl(voiceRegion, apiUrlOverrides);
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.VoiceUrl)
+                ? new Uri($"https://{voiceRegion.Value}.api.sinch.com/")
+                : new Uri(apiUrlOverrides.VoiceUrl);
+            voiceUrl.Should().BeEquivalentTo(expectedUrl);
+        }
+
+        public static IEnumerable<object[]> VoiceApplicationManagementData => new List<object[]>
+        {
+            new object[]
+            {
+                null
+            },
+            new object[]
+            {
+                new ApiUrlOverrides()
+                {
+                    VoiceApplicationManagementUrl = null
+                }
+            },
+            new object[]
+            {
+                new ApiUrlOverrides()
+                {
+                    VoiceApplicationManagementUrl = "https://hello.world"
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(VoiceApplicationManagementData))]
+        public void ResolveVoiceApplicationManagementUrl(ApiUrlOverrides apiUrlOverrides)
+        {
+            var voiceUrl = UrlResolver.ResolveVoiceApiApplicationManagementUrl(apiUrlOverrides);
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.VoiceApplicationManagementUrl)
+                ? new Uri($"https://callingapi.sinch.com/")
+                : new Uri(apiUrlOverrides.VoiceApplicationManagementUrl);
+            voiceUrl.Should().BeEquivalentTo(expectedUrl);
         }
     }
 }

--- a/tests/Sinch.Tests/Core/UrlResolverTests.cs
+++ b/tests/Sinch.Tests/Core/UrlResolverTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using FluentAssertions;
+using Sinch.Conversation;
+using Sinch.Core;
+using Xunit;
+
+namespace Sinch.Tests.Core
+{
+    public class UrlResolverTests
+    {
+        public static IEnumerable<object[]> ConversationUrlResolveData => new List<object[]>
+        {
+            new object[] { ConversationRegion.Eu, null },
+            new object[] { ConversationRegion.Br, null },
+            new object[] { ConversationRegion.Us, null },
+            new object[]
+            {
+                ConversationRegion.Us, new ApiUrlOverrides()
+                {
+                    ConversationUrl = null
+                }
+            },
+            new object[]
+            {
+                ConversationRegion.Us, new ApiUrlOverrides()
+                {
+                    ConversationUrl = "https://hello.world"
+                }
+            }
+        };
+
+        [Theory]
+        [MemberData(nameof(ConversationUrlResolveData))]
+        public void ResolveConversationUrl(ConversationRegion region, ApiUrlOverrides apiUrlOverrides)
+        {
+            var url = UrlResolver.ResolveConversationUrl(region, apiUrlOverrides);
+            var expectedUrl = string.IsNullOrEmpty(apiUrlOverrides?.ConversationUrl)
+                ? new Uri($"https://{region.Value}.conversation.api.sinch.com/")
+                : new Uri(apiUrlOverrides.ConversationUrl);
+            url.Should().BeEquivalentTo(expectedUrl);
+        }
+    }
+}

--- a/tests/Sinch.Tests/Helpers.cs
+++ b/tests/Sinch.Tests/Helpers.cs
@@ -18,7 +18,8 @@ namespace Sinch.Tests
             var field = instance!.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
             return (T)field!.GetValue(instance)!;
         }
-
+        
+        // Unused, but can be useful in future for tricky testing
         public static T InvokePrivateMethod<T, TInstance>(TInstance instance, string methodName, object[] parameters)
         {
             MethodInfo dynMethod = instance.GetType().GetMethod(methodName,

--- a/tests/Sinch.Tests/Helpers.cs
+++ b/tests/Sinch.Tests/Helpers.cs
@@ -19,6 +19,19 @@ namespace Sinch.Tests
             return (T)field!.GetValue(instance)!;
         }
 
+        public static T InvokePrivateMethod<T, TInstance>(TInstance instance, string methodName, object[] parameters)
+        {
+            MethodInfo dynMethod = instance.GetType().GetMethod(methodName,
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            if (dynMethod == null)
+            {
+                throw new InvalidOperationException($"{methodName} is not found on a type ${instance.GetType().Name}");
+            }
+
+            var returns = dynMethod.Invoke(instance, parameters);
+            return (T)returns;
+        }
+
         public static DateTime ParseUtc(string time)
         {
             return DateTime.Parse(time, CultureInfo.InvariantCulture).ToUniversalTime();

--- a/tests/Sinch.Tests/SinchClientTests.cs
+++ b/tests/Sinch.Tests/SinchClientTests.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http;
 using FluentAssertions;
-using Sinch.Conversation;
 using Xunit;
 
 namespace Sinch.Tests

--- a/tests/Sinch.Tests/SinchClientTests.cs
+++ b/tests/Sinch.Tests/SinchClientTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net.Http;
 using FluentAssertions;
+using Sinch.Conversation;
 using Xunit;
 
 namespace Sinch.Tests

--- a/tests/Sinch.Tests/e2e/TestBase.cs
+++ b/tests/Sinch.Tests/e2e/TestBase.cs
@@ -38,6 +38,8 @@ namespace Sinch.Tests.e2e
                     ConversationUrl = GetTestUrl("MOCK_CONVERSATION_PORT"),
                     NumbersUrl = GetTestUrl("MOCK_NUMBERS_PORT"),
                     VoiceUrl = GetTestUrl("MOCK_VOICE_PORT"),
+                    // Voice Application treated the same as voice in doppleganger
+                    VoiceApplicationManagementUrl = GetTestUrl("MOCK_VOICE_PORT"),
                     VerificationUrl = GetTestUrl("MOCK_VERIFICATION_PORT"),
                     // templates treated as conversation api in doppelganger 
                     TemplatesUrl = GetTestUrl("MOCK_CONVERSATION_PORT"),


### PR DESCRIPTION
In this PR, besides adding new `br` region to `ConversationRegions.cs`, I'm extracting url resolution logic from `SinchClient` to it's own class: `UrlResolver`. Tests added in `UrlResolverTests` to be sure urls are correctly resolved: url override takes precedence, and regions are templated correctly into url, if applicable. 

Also, adds `VoiceApplicationManagementUrl` to the list of overrides, as api endpoint is different from Voice, for the case when this override is needed. 