### PR TITLE
fix: build of restore with correct framework

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,10 @@ jobs:
         id: dotnet
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            6.0.x
+            7.0.x
+            8.0.x
 
       - name: Checkout Wiremock fixtures repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Now builds all frameworks in a single action