### PR TITLE
Remove duplicate FaxRegion from SinchOptions

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -12,6 +12,7 @@
 - [VoiceConfiguration and ScheduledVoiceProvisioning classes moved to new namespace](#voiceconfiguration-and-scheduledvoiceprovisioning-classes-moved-to-new-namespace)
 - [VoiceConfiguration Type property is now internal](#voiceconfiguration-type-property-is-now-internal)
 - [Removed obsolete UrlMessage and CallMessage constructors](#removed-obsolete-urlmessage-and-callmessage-constructors)
+- [FaxRegion moved from SinchOptions to SinchFaxConfiguration](#faxregion-moved-from-sinchoptions-to-sinchfaxconfiguration)
 
 ## Initialize `SinchClient` with unified credentials:
 
@@ -295,3 +296,28 @@ var callMessage = new CallMessage
     PhoneNumber = "+1234567890",
     Title = "Call us"
 };
+```
+
+## FaxRegion moved from SinchOptions to SinchFaxConfiguration
+
+The `FaxRegion` property has been removed from `SinchOptions`. Use the `Region` property on `SinchFaxConfiguration` instead.
+
+Version 1.*:
+```csharp
+var sinchClient = new SinchClient("PROJECT_ID", "KEY_ID", "KEY_SECRET", options =>
+{
+    options.FaxRegion = FaxRegion.Europe;
+});
+```
+
+Version 2.*:
+```csharp
+var sinchClient = new SinchClient(new SinchClientConfiguration()
+{
+    FaxConfiguration = new SinchFaxConfiguration()
+    {
+        Region = FaxRegion.Europe
+    }
+});
+```
+

--- a/src/Sinch/ServiceCollectionExtensions.cs
+++ b/src/Sinch/ServiceCollectionExtensions.cs
@@ -60,7 +60,6 @@ namespace Sinch
                     {
                         HttpClientFactory = configurationFactory.SinchOptions.HttpClientFactory ?? httpClientFactory,
                         LoggerFactory = configurationFactory.SinchOptions.LoggerFactory ?? loggerFactory,
-                        FaxRegion = configurationFactory.SinchOptions.FaxRegion,
                         ApiUrlOverrides = configurationFactory.SinchOptions.ApiUrlOverrides
                     };
                 }

--- a/src/Sinch/SinchOptions.cs
+++ b/src/Sinch/SinchOptions.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Net.Http;
 using Microsoft.Extensions.Logging;
-using Sinch.Fax;
 using Sinch.SMS;
 
 namespace Sinch
@@ -28,10 +27,6 @@ namespace Sinch
         /// </summary>
         public HttpClientHandlerConfiguration? HttpClientHandlerConfiguration { get; set; }
 
-        /// <summary>
-        ///     Set's the regions for the Fax api.
-        /// </summary>
-        public FaxRegion? FaxRegion { get; set; }
 
         /// <inheritdoc cref="ApiUrlOverrides"/>
         public ApiUrlOverrides? ApiUrlOverrides { get; set; }

--- a/tests/Sinch.Tests/Fax/FaxClientTests.cs
+++ b/tests/Sinch.Tests/Fax/FaxClientTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using FluentAssertions;
 using Sinch.Fax;
 using Xunit;

--- a/tests/Sinch.Tests/Fax/FaxClientTests.cs
+++ b/tests/Sinch.Tests/Fax/FaxClientTests.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using FluentAssertions;
+using Sinch.Fax;
+using Xunit;
+
+namespace Sinch.Tests.Fax
+{
+    public class FaxClientTests
+    {
+        [Fact]
+        public void FaxConfiguration_ShouldResolveDefaultUrl_WhenNoRegionSpecified()
+        {
+            var config = new SinchClientConfiguration()
+            {
+                SinchUnifiedCredentials = new SinchUnifiedCredentials()
+                {
+                    ProjectId = "PROJECT_ID",
+                    KeyId = "KEY_ID",
+                    KeySecret = "KEY_SECRET"
+                }
+            };
+            var faxUrl = config.FaxConfiguration.ResolveUrl();
+            faxUrl.Should().BeEquivalentTo(new Uri("https://fax.api.sinch.com/"));
+        }
+
+        [Fact]
+        public void FaxConfiguration_ShouldResolveEuropeUrl_WhenEuropeRegionSpecified()
+        {
+            var config = new SinchClientConfiguration()
+            {
+                SinchUnifiedCredentials = new SinchUnifiedCredentials()
+                {
+                    ProjectId = "PROJECT_ID",
+                    KeyId = "KEY_ID",
+                    KeySecret = "KEY_SECRET"
+                },
+                FaxConfiguration = new SinchFaxConfiguration()
+                {
+                    Region = FaxRegion.Europe
+                }
+            };
+            var faxUrl = config.FaxConfiguration.ResolveUrl();
+            faxUrl.Should().BeEquivalentTo(new Uri("https://eu1.fax.api.sinch.com/"));
+        }
+
+        [Fact]
+        public void FaxConfiguration_ShouldResolveUsEastCoastUrl_WhenUsEastCoastRegionSpecified()
+        {
+            var config = new SinchClientConfiguration()
+            {
+                SinchUnifiedCredentials = new SinchUnifiedCredentials()
+                {
+                    ProjectId = "PROJECT_ID",
+                    KeyId = "KEY_ID",
+                    KeySecret = "KEY_SECRET"
+                },
+                FaxConfiguration = new SinchFaxConfiguration()
+                {
+                    Region = FaxRegion.UsEastCost
+                }
+            };
+            var faxUrl = config.FaxConfiguration.ResolveUrl();
+            faxUrl.Should().BeEquivalentTo(new Uri("https://use1.fax.api.sinch.com/"));
+        }
+
+        [Fact]
+        public void FaxConfiguration_ShouldResolveSouthAmericaUrl_WhenSouthAmericaRegionSpecified()
+        {
+            var config = new SinchClientConfiguration()
+            {
+                SinchUnifiedCredentials = new SinchUnifiedCredentials()
+                {
+                    ProjectId = "PROJECT_ID",
+                    KeyId = "KEY_ID",
+                    KeySecret = "KEY_SECRET"
+                },
+                FaxConfiguration = new SinchFaxConfiguration()
+                {
+                    Region = FaxRegion.SouthAmerica
+                }
+            };
+            var faxUrl = config.FaxConfiguration.ResolveUrl();
+            faxUrl.Should().BeEquivalentTo(new Uri("https://sae1.fax.api.sinch.com/"));
+        }
+
+        [Fact]
+        public void FaxConfiguration_ShouldResolveSouthEastAsia1Url_WhenSouthEastAsia1RegionSpecified()
+        {
+            var config = new SinchClientConfiguration()
+            {
+                SinchUnifiedCredentials = new SinchUnifiedCredentials()
+                {
+                    ProjectId = "PROJECT_ID",
+                    KeyId = "KEY_ID",
+                    KeySecret = "KEY_SECRET"
+                },
+                FaxConfiguration = new SinchFaxConfiguration()
+                {
+                    Region = FaxRegion.SouthEastAsia1
+                }
+            };
+            var faxUrl = config.FaxConfiguration.ResolveUrl();
+            faxUrl.Should().BeEquivalentTo(new Uri("https://apse1.fax.api.sinch.com/"));
+        }
+
+        [Fact]
+        public void FaxConfiguration_ShouldResolveSouthEastAsia2Url_WhenSouthEastAsia2RegionSpecified()
+        {
+            var config = new SinchClientConfiguration()
+            {
+                SinchUnifiedCredentials = new SinchUnifiedCredentials()
+                {
+                    ProjectId = "PROJECT_ID",
+                    KeyId = "KEY_ID",
+                    KeySecret = "KEY_SECRET"
+                },
+                FaxConfiguration = new SinchFaxConfiguration()
+                {
+                    Region = FaxRegion.SouthEastAsia2
+                }
+            };
+            var faxUrl = config.FaxConfiguration.ResolveUrl();
+            faxUrl.Should().BeEquivalentTo(new Uri("https://apse2.fax.api.sinch.com/"));
+        }
+
+        [Fact]
+        public void FaxConfiguration_ShouldUseUrlOverride_WhenUrlOverrideSpecified()
+        {
+            var config = new SinchClientConfiguration()
+            {
+                SinchUnifiedCredentials = new SinchUnifiedCredentials()
+                {
+                    ProjectId = "PROJECT_ID",
+                    KeyId = "KEY_ID",
+                    KeySecret = "KEY_SECRET"
+                },
+                FaxConfiguration = new SinchFaxConfiguration()
+                {
+                    Region = FaxRegion.Europe, // This should be ignored when UrlOverride is set
+                    UrlOverride = "https://custom.fax.api.sinch.com/"
+                }
+            };
+            var faxUrl = config.FaxConfiguration.ResolveUrl();
+            faxUrl.Should().BeEquivalentTo(new Uri("https://custom.fax.api.sinch.com/"));
+        }
+    }
+}
+

--- a/tests/Sinch.Tests/Fax/FaxClientTests.cs
+++ b/tests/Sinch.Tests/Fax/FaxClientTests.cs
@@ -7,120 +7,29 @@ namespace Sinch.Tests.Fax
 {
     public class FaxClientTests
     {
-        [Fact]
-        public void FaxConfiguration_ShouldResolveDefaultUrl_WhenNoRegionSpecified()
+        public static TheoryData<FaxRegion, string> RegionUrlTestData => new()
         {
-            var config = new SinchClientConfiguration()
-            {
-                SinchUnifiedCredentials = new SinchUnifiedCredentials()
-                {
-                    ProjectId = "PROJECT_ID",
-                    KeyId = "KEY_ID",
-                    KeySecret = "KEY_SECRET"
-                }
-            };
-            var faxUrl = config.FaxConfiguration.ResolveUrl();
-            faxUrl.Should().BeEquivalentTo(new Uri("https://fax.api.sinch.com/"));
-        }
+            { null, "https://fax.api.sinch.com/" },
+            { FaxRegion.Europe, "https://eu1.fax.api.sinch.com/" },
+            { FaxRegion.UsEastCost, "https://use1.fax.api.sinch.com/" },
+            { FaxRegion.SouthAmerica, "https://sae1.fax.api.sinch.com/" },
+            { FaxRegion.SouthEastAsia1, "https://apse1.fax.api.sinch.com/" },
+            { FaxRegion.SouthEastAsia2, "https://apse2.fax.api.sinch.com/" },
+        };
 
-        [Fact]
-        public void FaxConfiguration_ShouldResolveEuropeUrl_WhenEuropeRegionSpecified()
+        [Theory]
+        [MemberData(nameof(RegionUrlTestData))]
+        public void FaxConfiguration_ShouldResolveCorrectUrl_WhenRegionSpecified(FaxRegion region, string expectedUrl)
         {
             var config = new SinchClientConfiguration()
             {
-                SinchUnifiedCredentials = new SinchUnifiedCredentials()
-                {
-                    ProjectId = "PROJECT_ID",
-                    KeyId = "KEY_ID",
-                    KeySecret = "KEY_SECRET"
-                },
                 FaxConfiguration = new SinchFaxConfiguration()
                 {
-                    Region = FaxRegion.Europe
+                    Region = region
                 }
             };
             var faxUrl = config.FaxConfiguration.ResolveUrl();
-            faxUrl.Should().BeEquivalentTo(new Uri("https://eu1.fax.api.sinch.com/"));
-        }
-
-        [Fact]
-        public void FaxConfiguration_ShouldResolveUsEastCoastUrl_WhenUsEastCoastRegionSpecified()
-        {
-            var config = new SinchClientConfiguration()
-            {
-                SinchUnifiedCredentials = new SinchUnifiedCredentials()
-                {
-                    ProjectId = "PROJECT_ID",
-                    KeyId = "KEY_ID",
-                    KeySecret = "KEY_SECRET"
-                },
-                FaxConfiguration = new SinchFaxConfiguration()
-                {
-                    Region = FaxRegion.UsEastCost
-                }
-            };
-            var faxUrl = config.FaxConfiguration.ResolveUrl();
-            faxUrl.Should().BeEquivalentTo(new Uri("https://use1.fax.api.sinch.com/"));
-        }
-
-        [Fact]
-        public void FaxConfiguration_ShouldResolveSouthAmericaUrl_WhenSouthAmericaRegionSpecified()
-        {
-            var config = new SinchClientConfiguration()
-            {
-                SinchUnifiedCredentials = new SinchUnifiedCredentials()
-                {
-                    ProjectId = "PROJECT_ID",
-                    KeyId = "KEY_ID",
-                    KeySecret = "KEY_SECRET"
-                },
-                FaxConfiguration = new SinchFaxConfiguration()
-                {
-                    Region = FaxRegion.SouthAmerica
-                }
-            };
-            var faxUrl = config.FaxConfiguration.ResolveUrl();
-            faxUrl.Should().BeEquivalentTo(new Uri("https://sae1.fax.api.sinch.com/"));
-        }
-
-        [Fact]
-        public void FaxConfiguration_ShouldResolveSouthEastAsia1Url_WhenSouthEastAsia1RegionSpecified()
-        {
-            var config = new SinchClientConfiguration()
-            {
-                SinchUnifiedCredentials = new SinchUnifiedCredentials()
-                {
-                    ProjectId = "PROJECT_ID",
-                    KeyId = "KEY_ID",
-                    KeySecret = "KEY_SECRET"
-                },
-                FaxConfiguration = new SinchFaxConfiguration()
-                {
-                    Region = FaxRegion.SouthEastAsia1
-                }
-            };
-            var faxUrl = config.FaxConfiguration.ResolveUrl();
-            faxUrl.Should().BeEquivalentTo(new Uri("https://apse1.fax.api.sinch.com/"));
-        }
-
-        [Fact]
-        public void FaxConfiguration_ShouldResolveSouthEastAsia2Url_WhenSouthEastAsia2RegionSpecified()
-        {
-            var config = new SinchClientConfiguration()
-            {
-                SinchUnifiedCredentials = new SinchUnifiedCredentials()
-                {
-                    ProjectId = "PROJECT_ID",
-                    KeyId = "KEY_ID",
-                    KeySecret = "KEY_SECRET"
-                },
-                FaxConfiguration = new SinchFaxConfiguration()
-                {
-                    Region = FaxRegion.SouthEastAsia2
-                }
-            };
-            var faxUrl = config.FaxConfiguration.ResolveUrl();
-            faxUrl.Should().BeEquivalentTo(new Uri("https://apse2.fax.api.sinch.com/"));
+            faxUrl.Should().BeEquivalentTo(new Uri(expectedUrl));
         }
 
         [Fact]
@@ -128,12 +37,6 @@ namespace Sinch.Tests.Fax
         {
             var config = new SinchClientConfiguration()
             {
-                SinchUnifiedCredentials = new SinchUnifiedCredentials()
-                {
-                    ProjectId = "PROJECT_ID",
-                    KeyId = "KEY_ID",
-                    KeySecret = "KEY_SECRET"
-                },
                 FaxConfiguration = new SinchFaxConfiguration()
                 {
                     Region = FaxRegion.Europe, // This should be ignored when UrlOverride is set


### PR DESCRIPTION
Currently, FaxRegion is configured at the SinchOptions level:

```
var options = new SinchOptions
{
    FaxRegion = FaxRegion.Us
};
```

However, SinchFaxConfiguration already has a  Region property:

`public FaxRegion? Region { get; init; }`

Suggested fix:
•	Remove `FaxRegion` property from `SinchOptions`
•	Ensure all usages reference `Region` instead