### PR TITLE
Refactor numbers tests to use sdk types

### DIFF
--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -311,7 +311,7 @@ namespace Sinch.Tests.Numbers
                 .Respond("application/json",
                     Helpers.LoadResources("Numbers/Active/ActiveNumber_VoiceRtc.json"));
 
-            var response = await Numbers.Update("+12025550134", 
+            var response = await Numbers.Update("+12025550134",
                 new UpdateActiveNumberRequest
                 {
                     DisplayName = "a display",
@@ -381,7 +381,7 @@ namespace Sinch.Tests.Numbers
                 .Respond("application/json",
                     Helpers.LoadResources("Numbers/Active/ActiveNumber_VoiceEst.json"));
 
-            var response = await Numbers.Update("+12025550134", 
+            var response = await Numbers.Update("+12025550134",
                 new UpdateActiveNumberRequest
                 {
                     DisplayName = "a display",
@@ -450,7 +450,7 @@ namespace Sinch.Tests.Numbers
                 .Respond("application/json",
                     Helpers.LoadResources("Numbers/Active/ActiveNumber_VoiceFax.json"));
 
-            var response = await Numbers.Update("+12025550134", 
+            var response = await Numbers.Update("+12025550134",
                 new UpdateActiveNumberRequest
                 {
                     DisplayName = "a display",

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -262,32 +262,211 @@ namespace Sinch.Tests.Numbers
         }
 
         [Fact]
-        public async Task UpdateActiveNumber()
+        public async Task UpdateActiveNumber_WithVoiceRtcConfiguration()
         {
+            var expectedActiveNumber = new ActiveNumber
+            {
+                PhoneNumber = "+447520651116XYZ",
+                ProjectId = "project id",
+                DisplayName = "a display",
+                RegionCode = "GB",
+                Type = Types.Mobile,
+                Capability = new List<Product> { Product.Sms, Product.Voice },
+                Money = new Money { CurrencyCode = "EUR", Amount = 0.8m },
+                PaymentIntervalMonths = 1,
+                NextChargeDate = Helpers.ParseUtc("2023-09-22T15:49:58.813424Z"),
+                ExpireAt = Helpers.ParseUtc("2023-10-06T15:49:58.813381Z"),
+                SmsConfiguration = new SmsConfiguration
+                {
+                    ServicePlanId = "service plan id",
+                    CampaignId = "campaign id",
+                    ScheduledProvisioning = new ScheduledProvisioning
+                    {
+                        ServicePlanId = "service plan id from scheduled",
+                        CampaignId = "campaign id from scheduled",
+                        Status = ProvisioningStatus.Unspecified,
+                        LastUpdatedTime = Helpers.ParseUtc("2023-09-25T12:08:02.115Z"),
+                        ErrorCodes = new List<string> { "ERROR_CODE_UNSPECIFIED" }
+                    }
+                },
+                VoiceConfiguration = new VoiceRtcConfiguration
+                {
+                    AppId = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEE",
+                    LastUpdatedTime = Helpers.ParseUtc("2024-06-30T07:08:09.100Z"),
+                    ScheduledVoiceProvisioning = new ScheduledVoiceRtcProvisioning
+                    {
+                        AppId = "EEEEEEEEEE-DDDD-CCCC-BBBB-AAAAAAAA",
+                        Status = ProvisioningStatus.Waiting,
+                        LastUpdatedTime = Helpers.ParseUtc("2024-07-01T11:58:35.610198Z"),
+                    }
+                },
+                CallbackUrl = "foo callback"
+            };
+
             HttpMessageHandlerMock
                 .When(HttpMethod.Patch,
                     $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers/+12025550134")
                 .WithHeaders("Authorization", $"Bearer {Token}")
-                .WithJson(Helpers.LoadResources("Numbers/Active/ActiveNumberUpdateRequest.json"))
+                .WithJson(Helpers.LoadResources("Numbers/Active/ActiveNumberUpdateRequest_VoiceRtc.json"))
                 .Respond("application/json",
-                    Helpers.LoadResources("Numbers/Active/ActiveNumber.json"));
+                    Helpers.LoadResources("Numbers/Active/ActiveNumber_VoiceRtc.json"));
 
-            var response = await Numbers.Update("+12025550134", new UpdateActiveNumberRequest()
+            var response = await Numbers.Update("+12025550134", 
+                new UpdateActiveNumberRequest
+                {
+                    DisplayName = "a display",
+                    SmsConfiguration = new SmsConfiguration()
+                    {
+                        ServicePlanId = "service plan id",
+                        CampaignId = "campaign id"
+                    },
+                    VoiceConfiguration = new VoiceRtcConfiguration()
+                    {
+                        AppId = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEE",
+                        Type = VoiceApplicationType.Rtc
+                    },
+                    CallbackUrl = "foo callback"
+                });
+
+            response.Should().BeEquivalentTo(expectedActiveNumber);
+        }
+
+        [Fact]
+        public async Task UpdateActiveNumber_WithVoiceEstConfiguration()
+        {
+            var expectedActiveNumber = new ActiveNumber
             {
+                PhoneNumber = "+447520651116XYZ",
+                ProjectId = "project id",
                 DisplayName = "a display",
-                SmsConfiguration = new SmsConfiguration()
+                RegionCode = "GB",
+                Type = Types.Mobile,
+                Capability = new List<Product> { Product.Sms, Product.Voice },
+                Money = new Money { CurrencyCode = "EUR", Amount = 0.8m },
+                PaymentIntervalMonths = 1,
+                NextChargeDate = Helpers.ParseUtc("2023-09-22T15:49:58.813424Z"),
+                ExpireAt = Helpers.ParseUtc("2023-10-06T15:49:58.813381Z"),
+                SmsConfiguration = new SmsConfiguration
                 {
                     ServicePlanId = "service plan id",
-                    CampaignId = "campaign id"
+                    CampaignId = "campaign id",
+                    ScheduledProvisioning = new ScheduledProvisioning
+                    {
+                        ServicePlanId = "service plan id from scheduled",
+                        CampaignId = "campaign id from scheduled",
+                        Status = ProvisioningStatus.Unspecified,
+                        LastUpdatedTime = Helpers.ParseUtc("2023-09-25T12:08:02.115Z"),
+                        ErrorCodes = new List<string> { "ERROR_CODE_UNSPECIFIED" }
+                    }
                 },
-                VoiceConfiguration = new VoiceRtcConfiguration()
+                VoiceConfiguration = new VoiceEstConfiguration
                 {
-                    AppId = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEE",
+                    TrunkId = "trunk-id-12345",
+                    LastUpdatedTime = Helpers.ParseUtc("2024-06-30T07:08:09.100Z"),
+                    ScheduledVoiceProvisioning = new ScheduledVoiceEstProvisioning
+                    {
+                        TrunkId = "trunk-id-scheduled",
+                        Status = ProvisioningStatus.Waiting,
+                        LastUpdatedTime = Helpers.ParseUtc("2024-07-01T11:58:35.610198Z"),
+                    }
                 },
                 CallbackUrl = "foo callback"
-            });
+            };
 
-            response.Should().BeEquivalentTo(_activeNumber);
+            HttpMessageHandlerMock
+                .When(HttpMethod.Patch,
+                    $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers/+12025550134")
+                .WithHeaders("Authorization", $"Bearer {Token}")
+                .WithJson(Helpers.LoadResources("Numbers/Active/ActiveNumberUpdateRequest_VoiceEst.json"))
+                .Respond("application/json",
+                    Helpers.LoadResources("Numbers/Active/ActiveNumber_VoiceEst.json"));
+
+            var response = await Numbers.Update("+12025550134", 
+                new UpdateActiveNumberRequest
+                {
+                    DisplayName = "a display",
+                    SmsConfiguration = new SmsConfiguration()
+                    {
+                        ServicePlanId = "service plan id",
+                        CampaignId = "campaign id"
+                    },
+                    VoiceConfiguration = new VoiceEstConfiguration()
+                    {
+                        TrunkId = "trunk-id-12345"
+                    },
+                    CallbackUrl = "foo callback"
+                });
+
+            response.Should().BeEquivalentTo(expectedActiveNumber);
+        }
+
+        [Fact]
+        public async Task UpdateActiveNumber_WithVoiceFaxConfiguration()
+        {
+            var expectedActiveNumber = new ActiveNumber
+            {
+                PhoneNumber = "+447520651116XYZ",
+                ProjectId = "project id",
+                DisplayName = "a display",
+                RegionCode = "GB",
+                Type = Types.Mobile,
+                Capability = new List<Product> { Product.Sms, Product.Voice },
+                Money = new Money { CurrencyCode = "EUR", Amount = 0.8m },
+                PaymentIntervalMonths = 1,
+                NextChargeDate = Helpers.ParseUtc("2023-09-22T15:49:58.813424Z"),
+                ExpireAt = Helpers.ParseUtc("2023-10-06T15:49:58.813381Z"),
+                SmsConfiguration = new SmsConfiguration
+                {
+                    ServicePlanId = "service plan id",
+                    CampaignId = "campaign id",
+                    ScheduledProvisioning = new ScheduledProvisioning
+                    {
+                        ServicePlanId = "service plan id from scheduled",
+                        CampaignId = "campaign id from scheduled",
+                        Status = ProvisioningStatus.Unspecified,
+                        LastUpdatedTime = Helpers.ParseUtc("2023-09-25T12:08:02.115Z"),
+                        ErrorCodes = new List<string> { "ERROR_CODE_UNSPECIFIED" }
+                    }
+                },
+                VoiceConfiguration = new VoiceFaxConfiguration
+                {
+                    ServiceId = "fax-service-id-12345",
+                    LastUpdatedTime = Helpers.ParseUtc("2024-06-30T07:08:09.100Z"),
+                    ScheduledVoiceProvisioning = new ScheduledVoiceFaxProvisioning
+                    {
+                        ServiceId = "fax-service-id-scheduled",
+                        Status = ProvisioningStatus.Waiting,
+                        LastUpdatedTime = Helpers.ParseUtc("2024-07-01T11:58:35.610198Z"),
+                    }
+                },
+                CallbackUrl = "foo callback"
+            };
+
+            HttpMessageHandlerMock
+                .When(HttpMethod.Patch,
+                    $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers/+12025550134")
+                .WithHeaders("Authorization", $"Bearer {Token}")
+                .WithJson(Helpers.LoadResources("Numbers/Active/ActiveNumberUpdateRequest_VoiceFax.json"))
+                .Respond("application/json",
+                    Helpers.LoadResources("Numbers/Active/ActiveNumber_VoiceFax.json"));
+
+            var response = await Numbers.Update("+12025550134", 
+                new UpdateActiveNumberRequest
+                {
+                    DisplayName = "a display",
+                    SmsConfiguration = new SmsConfiguration()
+                    {
+                        ServicePlanId = "service plan id",
+                        CampaignId = "campaign id"
+                    },
+                    VoiceConfiguration = new VoiceFaxConfiguration()
+                    {
+                        ServiceId = "fax-service-id-12345"
+                    },
+                    CallbackUrl = "foo callback"
+                });
+
+            response.Should().BeEquivalentTo(expectedActiveNumber);
         }
     }
 }

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using RichardSzalay.MockHttp;
@@ -256,7 +257,7 @@ namespace Sinch.Tests.Numbers
         public void DeserializeActiveNumber()
         {
             var json = Helpers.LoadResources("Numbers/Active/ActiveNumber.json");
-            var activeNumber = DeserializeAsNumbersClient<ActiveNumber>(json);
+            var activeNumber = JsonSerializer.Deserialize<ActiveNumber>(json, Numbers.JsonSerializerOptions);
             activeNumber.Should().BeOfType<ActiveNumber>().And.BeEquivalentTo(_activeNumber);
         }
 

--- a/tests/Sinch.Tests/Numbers/NumberTestBase.cs
+++ b/tests/Sinch.Tests/Numbers/NumberTestBase.cs
@@ -14,18 +14,5 @@ namespace Sinch.Tests.Numbers
             Numbers = new Sinch.Numbers.Numbers(ProjectId,
                 new Uri("https://numbers.api.sinch.com/"), default, HttpCamelCase);
         }
-
-        protected string SerializeAsNumbersClient<T>(T value)
-        {
-            return JsonSerializer.Serialize(value, Numbers.JsonSerializerOptions);
-        }
-
-        protected T DeserializeAsNumbersClient<T>(string json)
-        {
-            // for unit tests worth checking if model is missing properties from json
-            var withFailOnUnexpectedProps = new JsonSerializerOptions(Numbers.JsonSerializerOptions);
-            withFailOnUnexpectedProps.UnmappedMemberHandling = JsonUnmappedMemberHandling.Disallow;
-            return JsonSerializer.Deserialize<T>(json, withFailOnUnexpectedProps);
-        }
     }
 }

--- a/tests/Sinch.Tests/Numbers/NumberTestBase.cs
+++ b/tests/Sinch.Tests/Numbers/NumberTestBase.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Sinch.Numbers;
 
 namespace Sinch.Tests.Numbers

--- a/tests/Sinch.Tests/Numbers/VoiceConfigurationConverterTests.cs
+++ b/tests/Sinch.Tests/Numbers/VoiceConfigurationConverterTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace Sinch.Tests.Numbers
 {
-    public class VoiceConfigurationTests : NumberTestBase
+    public class VoiceConfigurationConverterTests : NumberTestBase
     {
         private class Container
         {

--- a/tests/Sinch.Tests/Numbers/VoiceConfigurationConverterTests.cs
+++ b/tests/Sinch.Tests/Numbers/VoiceConfigurationConverterTests.cs
@@ -29,7 +29,7 @@ namespace Sinch.Tests.Numbers
                 AppId = "app id value",
             };
             var jsonString = JsonSerializer.Serialize(
-                new Container { VoiceConfiguration = config }, 
+                new Container { VoiceConfiguration = config },
                 Numbers.JsonSerializerOptions);
 
             Helpers.AssertJsonEqual(Helpers.LoadResources("Numbers/RtcVoiceSerializationExpected.json"), jsonString);
@@ -43,7 +43,7 @@ namespace Sinch.Tests.Numbers
                 ServiceId = "service id value",
             };
             var jsonString = JsonSerializer.Serialize(
-                new Container { VoiceConfiguration = config }, 
+                new Container { VoiceConfiguration = config },
                 Numbers.JsonSerializerOptions);
 
             Helpers.AssertJsonEqual(Helpers.LoadResources("Numbers/FaxVoiceSerializationExpected.json"), jsonString);
@@ -57,7 +57,7 @@ namespace Sinch.Tests.Numbers
                 TrunkId = "trunk id value",
             };
             var jsonString = JsonSerializer.Serialize(
-                new Container { VoiceConfiguration = config }, 
+                new Container { VoiceConfiguration = config },
                 Numbers.JsonSerializerOptions);
 
             Helpers.AssertJsonEqual(Helpers.LoadResources("Numbers/EstVoiceSerializationExpected.json"), jsonString);
@@ -67,7 +67,7 @@ namespace Sinch.Tests.Numbers
         public void ShouldDeserializeVoiceEstConfiguration()
         {
             var obj = JsonSerializer.Deserialize<Container>(
-                Helpers.LoadResources("Numbers/EstVoiceResponse.json"), 
+                Helpers.LoadResources("Numbers/EstVoiceResponse.json"),
                 Numbers.JsonSerializerOptions);
 
             var prov = new ScheduledVoiceEstProvisioning()

--- a/tests/Sinch.Tests/Numbers/VoiceConfigurationTests.cs
+++ b/tests/Sinch.Tests/Numbers/VoiceConfigurationTests.cs
@@ -28,10 +28,9 @@ namespace Sinch.Tests.Numbers
             {
                 AppId = "app id value",
             };
-            var jsonString = SerializeAsNumbersClient(new Container()
-            {
-                VoiceConfiguration = config
-            });
+            var jsonString = JsonSerializer.Serialize(
+                new Container { VoiceConfiguration = config }, 
+                Numbers.JsonSerializerOptions);
 
             Helpers.AssertJsonEqual(Helpers.LoadResources("Numbers/RtcVoiceSerializationExpected.json"), jsonString);
         }
@@ -43,10 +42,9 @@ namespace Sinch.Tests.Numbers
             {
                 ServiceId = "service id value",
             };
-            var jsonString = SerializeAsNumbersClient(new Container()
-            {
-                VoiceConfiguration = config
-            });
+            var jsonString = JsonSerializer.Serialize(
+                new Container { VoiceConfiguration = config }, 
+                Numbers.JsonSerializerOptions);
 
             Helpers.AssertJsonEqual(Helpers.LoadResources("Numbers/FaxVoiceSerializationExpected.json"), jsonString);
         }
@@ -58,10 +56,9 @@ namespace Sinch.Tests.Numbers
             {
                 TrunkId = "trunk id value",
             };
-            var jsonString = SerializeAsNumbersClient(new Container()
-            {
-                VoiceConfiguration = config
-            });
+            var jsonString = JsonSerializer.Serialize(
+                new Container { VoiceConfiguration = config }, 
+                Numbers.JsonSerializerOptions);
 
             Helpers.AssertJsonEqual(Helpers.LoadResources("Numbers/EstVoiceSerializationExpected.json"), jsonString);
         }
@@ -69,9 +66,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ShouldDeserializeVoiceEstConfiguration()
         {
-            var obj =
-                DeserializeAsNumbersClient<Container>(
-                    Helpers.LoadResources("Numbers/EstVoiceResponse.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/EstVoiceResponse.json"), 
+                Numbers.JsonSerializerOptions);
 
             var prov = new ScheduledVoiceEstProvisioning()
             {
@@ -95,9 +92,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ShouldDeserializeVoiceFaxConfiguration()
         {
-            var obj =
-                DeserializeAsNumbersClient<Container>(
-                    Helpers.LoadResources("Numbers/FaxVoiceResponse.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/FaxVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             var scheduledVoiceFaxProvisioning = new ScheduledVoiceFaxProvisioning()
             {
@@ -122,7 +119,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ShouldDeserializeVoiceRtcConfiguration()
         {
-            var container = DeserializeAsNumbersClient<Container>(Helpers.LoadResources("Numbers/RtcVoiceResponse.json"));
+            var container = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/RtcVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             var expectedProvisioning = new ScheduledVoiceRtcProvisioning()
             {
@@ -152,8 +151,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ScheduledVoiceRtcProvisioning_ShouldDeserializeToConcreteType()
         {
-            var obj = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/RtcVoiceResponse.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/RtcVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             var voiceRtc = (VoiceRtcConfiguration)obj.VoiceConfiguration;
 
@@ -173,8 +173,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ScheduledVoiceFaxProvisioning_ShouldDeserializeToConcreteType()
         {
-            var container = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/FaxVoiceResponse.json"));
+            var container = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/FaxVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             var voiceFax = (VoiceFaxConfiguration)container.VoiceConfiguration;
             voiceFax.ScheduledVoiceProvisioning.Should().BeOfType<ScheduledVoiceFaxProvisioning>();
@@ -183,8 +184,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ScheduledVoiceEstProvisioning_ShouldDeserializeToConcreteType()
         {
-            var container = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/EstVoiceResponse.json"));
+            var container = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/EstVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             var voiceEst = (VoiceEstConfiguration)container.VoiceConfiguration;
             voiceEst.ScheduledVoiceProvisioning.Should().BeOfType<ScheduledVoiceEstProvisioning>();
@@ -193,8 +195,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void VoiceRtcConfiguration_ShouldDeserializeToConcreteType()
         {
-            var obj = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/RtcVoiceResponse.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/RtcVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             obj.VoiceConfiguration.Should().BeOfType<VoiceRtcConfiguration>();
         }
@@ -202,8 +205,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void VoiceEstConfiguration_ShouldDeserializeToConcreteType()
         {
-            var obj = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/EstVoiceResponse.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/EstVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             obj.VoiceConfiguration.Should().BeOfType<VoiceEstConfiguration>();
         }
@@ -211,8 +215,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void VoiceFaxConfiguration_ShouldDeserializeToConcreteType()
         {
-            var obj = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/FaxVoiceResponse.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/FaxVoiceResponse.json"),
+                Numbers.JsonSerializerOptions);
 
             obj.VoiceConfiguration.Should().BeOfType<VoiceFaxConfiguration>();
         }
@@ -222,7 +227,7 @@ namespace Sinch.Tests.Numbers
         {
             var unknownJson = """{"voiceConfiguration": {"type": "UNKNOWN"}}""";
 
-            var act = () => DeserializeAsNumbersClient<Container>(unknownJson);
+            var act = () => JsonSerializer.Deserialize<Container>(unknownJson, Numbers.JsonSerializerOptions);
 
             act.Should().Throw<JsonException>()
                 .WithMessage("*Type tag is invalid*");
@@ -233,7 +238,7 @@ namespace Sinch.Tests.Numbers
         {
             var noTypeJson = """{"voiceConfiguration": {"lastUpdatedTime": "2024-07-01T11:58:35.610198Z"}}""";
 
-            var act = () => DeserializeAsNumbersClient<Container>(noTypeJson);
+            var act = () => JsonSerializer.Deserialize<Container>(noTypeJson, Numbers.JsonSerializerOptions);
 
             act.Should().Throw<JsonException>()
                 .WithMessage("*Failed to deserialize VoiceConfiguration*");
@@ -247,8 +252,8 @@ namespace Sinch.Tests.Numbers
                 AppId = "test-app-id"
             };
 
-            var json = SerializeAsNumbersClient(new Container { VoiceConfiguration = original });
-            var deserialized = DeserializeAsNumbersClient<Container>(json);
+            var json = JsonSerializer.Serialize(new Container { VoiceConfiguration = original }, Numbers.JsonSerializerOptions);
+            var deserialized = JsonSerializer.Deserialize<Container>(json, Numbers.JsonSerializerOptions);
 
             deserialized.VoiceConfiguration.Should().BeOfType<VoiceRtcConfiguration>();
             var rtcConfig = (VoiceRtcConfiguration)deserialized.VoiceConfiguration;
@@ -264,8 +269,8 @@ namespace Sinch.Tests.Numbers
                 ServiceId = "test-service-id"
             };
 
-            var json = SerializeAsNumbersClient(new Container { VoiceConfiguration = original });
-            var deserialized = DeserializeAsNumbersClient<Container>(json);
+            var json = JsonSerializer.Serialize(new Container { VoiceConfiguration = original }, Numbers.JsonSerializerOptions);
+            var deserialized = JsonSerializer.Deserialize<Container>(json, Numbers.JsonSerializerOptions);
 
             deserialized.VoiceConfiguration.Should().BeOfType<VoiceFaxConfiguration>();
             var faxConfig = (VoiceFaxConfiguration)deserialized.VoiceConfiguration;
@@ -281,8 +286,8 @@ namespace Sinch.Tests.Numbers
                 TrunkId = "test-trunk-id"
             };
 
-            var json = SerializeAsNumbersClient(new Container { VoiceConfiguration = original });
-            var deserialized = DeserializeAsNumbersClient<Container>(json);
+            var json = JsonSerializer.Serialize(new Container { VoiceConfiguration = original }, Numbers.JsonSerializerOptions);
+            var deserialized = JsonSerializer.Deserialize<Container>(json, Numbers.JsonSerializerOptions);
 
             deserialized.VoiceConfiguration.Should().BeOfType<VoiceEstConfiguration>();
             var estConfig = (VoiceEstConfiguration)deserialized.VoiceConfiguration;
@@ -319,8 +324,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ShouldDeserializeVoiceRtcConfigurationButWithFaxProvisioning()
         {
-            var obj = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/RtcVoiceConfigWithFaxProvisioning.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/RtcVoiceConfigWithFaxProvisioning.json"),
+                Numbers.JsonSerializerOptions);
 
             obj.VoiceConfiguration.Should().BeOfType<VoiceRtcConfiguration>();
             obj.VoiceConfiguration.ScheduledVoiceProvisioning.Should().BeOfType<ScheduledVoiceFaxProvisioning>();
@@ -329,8 +335,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ShouldDeserializeVoiceEstConfigurationWithRtcProvisioning()
         {
-            var obj = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/EstVoiceConfigWithRtcProvisioning.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/EstVoiceConfigWithRtcProvisioning.json"),
+                Numbers.JsonSerializerOptions);
 
             obj.VoiceConfiguration.Should().BeOfType<VoiceEstConfiguration>();
             obj.VoiceConfiguration.ScheduledVoiceProvisioning.Should().BeOfType<ScheduledVoiceRtcProvisioning>();
@@ -339,8 +346,9 @@ namespace Sinch.Tests.Numbers
         [Fact]
         public void ShouldDeserializeVoiceFaxConfigurationWithEstProvisioning()
         {
-            var obj = DeserializeAsNumbersClient<Container>(
-                Helpers.LoadResources("Numbers/FaxVoiceConfigWithEstProvisioning.json"));
+            var obj = JsonSerializer.Deserialize<Container>(
+                Helpers.LoadResources("Numbers/FaxVoiceConfigWithEstProvisioning.json"),
+                Numbers.JsonSerializerOptions);
 
             obj.VoiceConfiguration.Should().BeOfType<VoiceFaxConfiguration>();
             obj.VoiceConfiguration.ScheduledVoiceProvisioning.Should().BeOfType<ScheduledVoiceEstProvisioning>();

--- a/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumberUpdateRequest_VoiceEst.json
+++ b/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumberUpdateRequest_VoiceEst.json
@@ -1,0 +1,13 @@
+﻿{
+  "displayName": "a display",
+  "smsConfiguration": {
+    "servicePlanId": "service plan id",
+    "campaignId": "campaign id"
+  },
+  "voiceConfiguration": {
+    "trunkId": "trunk-id-12345",
+    "type": "EST"
+  },
+  "callbackUrl": "foo callback"
+}
+

--- a/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumberUpdateRequest_VoiceFax.json
+++ b/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumberUpdateRequest_VoiceFax.json
@@ -1,0 +1,13 @@
+﻿{
+  "displayName": "a display",
+  "smsConfiguration": {
+    "servicePlanId": "service plan id",
+    "campaignId": "campaign id"
+  },
+  "voiceConfiguration": {
+    "serviceId": "fax-service-id-12345",
+    "type": "FAX"
+  },
+  "callbackUrl": "foo callback"
+}
+

--- a/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumberUpdateRequest_VoiceRtc.json
+++ b/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumberUpdateRequest_VoiceRtc.json
@@ -1,0 +1,12 @@
+﻿{
+  "displayName": "a display",
+  "smsConfiguration": {
+    "servicePlanId": "service plan id",
+    "campaignId": "campaign id"
+  },
+  "voiceConfiguration": {
+    "appId": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEE",
+    "type": "RTC"
+  },
+  "callbackUrl": "foo callback"
+}

--- a/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumber_VoiceEst.json
+++ b/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumber_VoiceEst.json
@@ -1,0 +1,44 @@
+﻿{
+  "phoneNumber": "+447520651116XYZ",
+  "projectId": "project id",
+  "displayName": "a display",
+  "regionCode": "GB",
+  "type": "MOBILE",
+  "capability": [
+    "SMS",
+    "VOICE"
+  ],
+  "money": {
+    "currencyCode": "EUR",
+    "amount": "0.8"
+  },
+  "paymentIntervalMonths": 1,
+  "nextChargeDate": "2023-09-22T15:49:58.813424Z",
+  "expireAt": "2023-10-06T15:49:58.813381Z",
+  "smsConfiguration": {
+    "servicePlanId": "service plan id",
+    "campaignId": "campaign id",
+    "scheduledProvisioning": {
+      "servicePlanId": "service plan id from scheduled",
+      "campaignId": "campaign id from scheduled",
+      "status": "PROVISIONING_STATUS_UNSPECIFIED",
+      "lastUpdatedTime": "2023-09-25T12:08:02.115Z",
+      "errorCodes": [
+        "ERROR_CODE_UNSPECIFIED"
+      ]
+    }
+  },
+  "voiceConfiguration": {
+    "trunkId": "trunk-id-12345",
+    "scheduledVoiceProvisioning": {
+      "trunkId": "trunk-id-scheduled",
+      "status": "WAITING",
+      "lastUpdatedTime": "2024-07-01T11:58:35.610198Z",
+      "type": "EST"
+    },
+    "lastUpdatedTime": "2024-06-30T07:08:09.100Z",
+    "type": "EST"
+  },
+  "callbackUrl": "foo callback"
+}
+

--- a/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumber_VoiceFax.json
+++ b/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumber_VoiceFax.json
@@ -1,0 +1,44 @@
+﻿{
+  "phoneNumber": "+447520651116XYZ",
+  "projectId": "project id",
+  "displayName": "a display",
+  "regionCode": "GB",
+  "type": "MOBILE",
+  "capability": [
+    "SMS",
+    "VOICE"
+  ],
+  "money": {
+    "currencyCode": "EUR",
+    "amount": "0.8"
+  },
+  "paymentIntervalMonths": 1,
+  "nextChargeDate": "2023-09-22T15:49:58.813424Z",
+  "expireAt": "2023-10-06T15:49:58.813381Z",
+  "smsConfiguration": {
+    "servicePlanId": "service plan id",
+    "campaignId": "campaign id",
+    "scheduledProvisioning": {
+      "servicePlanId": "service plan id from scheduled",
+      "campaignId": "campaign id from scheduled",
+      "status": "PROVISIONING_STATUS_UNSPECIFIED",
+      "lastUpdatedTime": "2023-09-25T12:08:02.115Z",
+      "errorCodes": [
+        "ERROR_CODE_UNSPECIFIED"
+      ]
+    }
+  },
+  "voiceConfiguration": {
+    "serviceId": "fax-service-id-12345",
+    "scheduledVoiceProvisioning": {
+      "serviceId": "fax-service-id-scheduled",
+      "status": "WAITING",
+      "lastUpdatedTime": "2024-07-01T11:58:35.610198Z",
+      "type": "FAX"
+    },
+    "lastUpdatedTime": "2024-06-30T07:08:09.100Z",
+    "type": "FAX"
+  },
+  "callbackUrl": "foo callback"
+}
+

--- a/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumber_VoiceRtc.json
+++ b/tests/Sinch.Tests/Resources/Numbers/Active/ActiveNumber_VoiceRtc.json
@@ -1,0 +1,44 @@
+﻿{
+  "phoneNumber": "+447520651116XYZ",
+  "projectId": "project id",
+  "displayName": "a display",
+  "regionCode": "GB",
+  "type": "MOBILE",
+  "capability": [
+    "SMS",
+    "VOICE"
+  ],
+  "money": {
+    "currencyCode": "EUR",
+    "amount": "0.8"
+  },
+  "paymentIntervalMonths": 1,
+  "nextChargeDate": "2023-09-22T15:49:58.813424Z",
+  "expireAt": "2023-10-06T15:49:58.813381Z",
+  "smsConfiguration": {
+    "servicePlanId": "service plan id",
+    "campaignId": "campaign id",
+    "scheduledProvisioning": {
+      "servicePlanId": "service plan id from scheduled",
+      "campaignId": "campaign id from scheduled",
+      "status": "PROVISIONING_STATUS_UNSPECIFIED",
+      "lastUpdatedTime": "2023-09-25T12:08:02.115Z",
+      "errorCodes": [
+        "ERROR_CODE_UNSPECIFIED"
+      ]
+    }
+  },
+  "voiceConfiguration": {
+    "appId": "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEE",
+    "scheduledVoiceProvisioning": {
+      "appId": "EEEEEEEEEE-DDDD-CCCC-BBBB-AAAAAAAA",
+      "status": "WAITING",
+      "lastUpdatedTime": "2024-07-01T11:58:35.610198Z",
+      "type": "RTC"
+    },
+    "lastUpdatedTime": "2024-06-30T07:08:09.100Z",
+    "type": "RTC"
+  },
+  "callbackUrl": "foo callback"
+}
+


### PR DESCRIPTION
## Summary

`NumberTestBase.cs` and related `VoiceConfigurationTests.cs` tests use custom test infrastructure that doesn't accurately replicate real SDK behavior. This makes the tests less reliable for validating production deserialization.

`NumberTestBase.cs` is using `SerializeAsNumbersClient.cs` and `DeserializeAsNumbersClient` utility methods with custom serialization options.
