### PR TITLE
Rename numbers callbacks to callbackconfiguration

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -12,6 +12,7 @@
 - [VoiceConfiguration and ScheduledVoiceProvisioning classes moved to new namespace](#voiceconfiguration-and-scheduledvoiceprovisioning-classes-moved-to-new-namespace)
 - [VoiceConfiguration Type property is now internal](#voiceconfiguration-type-property-is-now-internal)
 - [Removed obsolete UrlMessage and CallMessage constructors](#removed-obsolete-urlmessage-and-callmessage-constructors)
+- [Numbers API: Callbacks renamed to CallbackConfiguration](#callbacks-renamed-to-callbackconfiguration)
 
 ## Initialize `SinchClient` with unified credentials:
 
@@ -295,3 +296,19 @@ var callMessage = new CallMessage
     PhoneNumber = "+1234567890",
     Title = "Call us"
 };
+
+```
+
+## Numbers API
+
+The `Callbacks` property on `ISinchNumbers` has been renamed to `CallbackConfiguration` for clarity and consistency.
+
+Version 1.*:
+```csharp
+var callbacks = sinchClient.Numbers.Callbacks;
+```
+
+Version 2.*:
+```csharp
+var callbackConfiguration = sinchClient.Numbers.CallbackConfiguration;
+```

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -322,12 +322,9 @@ var sinchClient = new SinchClient(new SinchClientConfiguration()
 });
 ```
 
-
-```
-
 ## Numbers API
 
-The `Callbacks` property on `ISinchNumbers` has been renamed to `CallbackConfiguration` for clarity and consistency.
+The `Callbacks` property on `ISinchNumbers` has been renamed to `CallbackConfiguration`.
 
 Version 1.*:
 ```csharp

--- a/examples/snippets/Snippets.sln
+++ b/examples/snippets/Snippets.sln
@@ -9,7 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "numbers", "numbers", "{1F3F
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "regions", "regions", "{C9ABC05C-1010-AA2A-AAD9-A3A6DB064F27}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "callbacks", "callbacks", "{556E60D1-386E-388B-3939-689550C4E04E}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "callbackConfiguration", "callbackConfiguration", "{556E60D1-386E-388B-3939-689550C4E04E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Shared", "Shared", "{4F52FD11-658E-A102-6CD3-7D7C16FFA15B}"
 EndProject

--- a/examples/snippets/numbers/callbacks/Get/Get.cs
+++ b/examples/snippets/numbers/callbacks/Get/Get.cs
@@ -22,6 +22,6 @@ var sinchClient = new SinchClient(new SinchClientConfiguration()
 
 Console.WriteLine("Get callback configuration");
 
-var response = await sinchClient.Numbers.Callbacks.Get();
+var response = await sinchClient.Numbers.CallbackConfiguration.Get();
 
 Console.WriteLine($"Response: {response.ToPrettyString()}");

--- a/examples/snippets/numbers/callbacks/Update/Update.cs
+++ b/examples/snippets/numbers/callbacks/Update/Update.cs
@@ -24,6 +24,6 @@ var hmacSecret = "NEW_HMAC_SECRET";
 
 Console.WriteLine("Update callback HMAC secret");
 
-var response = await sinchClient.Numbers.Callbacks.Update(hmacSecret);
+var response = await sinchClient.Numbers.CallbackConfiguration.Update(hmacSecret);
 
 Console.WriteLine($"Response: {response.ToPrettyString()}");

--- a/src/Sinch/Numbers/CallbackConfiguration/CallbackConfiguration.cs
+++ b/src/Sinch/Numbers/CallbackConfiguration/CallbackConfiguration.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using System.Text.Json.Serialization;
 
-namespace Sinch.Numbers.Callbacks
+namespace Sinch.Numbers.CallbackConfiguration
 {
     /// <summary>
     ///     Response message containing the callbacks configuration for a specific project

--- a/src/Sinch/Numbers/CallbackConfiguration/SinchNumbersCallbacks.cs
+++ b/src/Sinch/Numbers/CallbackConfiguration/SinchNumbersCallbacks.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using Sinch.Core;
 using Sinch.Logger;
 
-namespace Sinch.Numbers.Callbacks
+namespace Sinch.Numbers.CallbackConfiguration
 {
     /// <summary>
     /// You can set up callback URLs to receive event notifications when your numbers are updated.
@@ -56,7 +56,7 @@ namespace Sinch.Numbers.Callbacks
     /// <b>Note:</b> Compute the HMAC on the plain text value before parsing the JSON payload.
     /// </para>
     /// </remarks>
-    public interface ISinchNumbersCallbacks
+    public interface ISinchNumbersCallbackConfiguration
     {
         /// <summary>
         ///     Returns the callbacks configuration for your project
@@ -74,14 +74,14 @@ namespace Sinch.Numbers.Callbacks
         Task<CallbackConfiguration> Update(string hmacSecret, CancellationToken cancellationToken = default);
     }
 
-    internal sealed class SinchNumbersCallbacks : ISinchNumbersCallbacks
+    internal sealed class SinchNumbersCallbackConfiguration : ISinchNumbersCallbackConfiguration
     {
         private readonly Uri _baseAddress;
         private readonly IHttp _http;
-        private readonly ILoggerAdapter<ISinchNumbersCallbacks>? _logger;
+        private readonly ILoggerAdapter<ISinchNumbersCallbackConfiguration>? _logger;
         private readonly string _projectId;
 
-        public SinchNumbersCallbacks(string projectId, Uri baseAddress, ILoggerAdapter<ISinchNumbersCallbacks>? logger,
+        public SinchNumbersCallbackConfiguration(string projectId, Uri baseAddress, ILoggerAdapter<ISinchNumbersCallbackConfiguration>? logger,
             IHttp http)
         {
             _projectId = projectId;

--- a/src/Sinch/Numbers/Numbers.cs
+++ b/src/Sinch/Numbers/Numbers.cs
@@ -13,7 +13,7 @@ using Sinch.Numbers.Available;
 using Sinch.Numbers.Available.List;
 using Sinch.Numbers.Available.Rent;
 using Sinch.Numbers.Available.RentAny;
-using Sinch.Numbers.Callbacks;
+using Sinch.Numbers.CallbackConfiguration;
 
 namespace Sinch.Numbers
 {
@@ -28,8 +28,8 @@ namespace Sinch.Numbers
         /// </summary>
         public ISinchNumbersRegions Regions { get; }
 
-        /// <inheritdoc cref="ISinchNumbersCallbacks"/>
-        public ISinchNumbersCallbacks Callbacks { get; }
+        /// <inheritdoc cref="ISinchNumbersCallbackConfiguration"/>
+        public ISinchNumbersCallbackConfiguration CallbackConfiguration { get; }
 
         /// <inheritdoc cref="ISinchNumbersAvailable.RentAny" />
         Task<ActiveNumber> RentAny(RentAnyNumberRequest request,
@@ -104,14 +104,14 @@ namespace Sinch.Numbers
                 loggerFactory?.Create<ActiveNumbers>(), http);
             _available = new AvailableNumbers(projectId, baseAddress,
                 loggerFactory?.Create<AvailableNumbers>(), http);
-            Callbacks = new SinchNumbersCallbacks(projectId, baseAddress,
-                loggerFactory?.Create<ISinchNumbersCallbacks>(), http);
+            CallbackConfiguration = new SinchNumbersCallbackConfiguration(projectId, baseAddress,
+                loggerFactory?.Create<ISinchNumbersCallbackConfiguration>(), http);
             JsonSerializerOptions = http.JsonSerializerOptions;
         }
 
         public ISinchNumbersRegions Regions { get; }
 
-        public ISinchNumbersCallbacks Callbacks { get; }
+        public ISinchNumbersCallbackConfiguration CallbackConfiguration { get; }
 
         /// <inheritdoc />
         public Task<ActiveNumber> RentAny(RentAnyNumberRequest request, CancellationToken cancellationToken = default)

--- a/tests/Sinch.Tests.Features/Numbers/CallbackConfiguration.cs
+++ b/tests/Sinch.Tests.Features/Numbers/CallbackConfiguration.cs
@@ -3,28 +3,28 @@ using System.Net;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
-using Sinch.Numbers.Callbacks;
+using Sinch.Numbers.CallbackConfiguration;
 
 namespace Sinch.Tests.Features.Numbers
 {
     [Binding]
     public class CallbackConfigurations
     {
-        private ISinchNumbersCallbacks _sinchNumbersCallbacks;
+        private ISinchNumbersCallbackConfiguration _sinchNumbersCallbackConfiguration;
         private CallbackConfiguration _callbackConfig;
         private Func<Task<CallbackConfiguration>> _callbackConfigOp;
 
         [Given(@"the Numbers service ""Callback Configuration"" is available")]
         public void GivenTheNumbersServiceIsAvailable()
         {
-            _sinchNumbersCallbacks = Utils.SinchNumbersClient().Callbacks;
+            _sinchNumbersCallbackConfiguration = Utils.SinchNumbersClient().CallbackConfiguration;
         }
 
 
         [When(@"I send a request to retrieve the callback configuration")]
         public async Task WhenISendARequestToRetrieveTheCallbackConfiguration()
         {
-            _callbackConfig = await _sinchNumbersCallbacks.Get();
+            _callbackConfig = await _sinchNumbersCallbackConfiguration.Get();
         }
 
         [Then(@"the response contains the project's callback configuration")]
@@ -40,7 +40,7 @@ namespace Sinch.Tests.Features.Numbers
         [When(@"I send a request to update the callback configuration with the secret ""(.*)""")]
         public void WhenISendARequestToUpdateTheCallbackConfigurationWithTheSecret(string hmacSecret)
         {
-            _callbackConfigOp = () => _sinchNumbersCallbacks.Update(hmacSecret);
+            _callbackConfigOp = () => _sinchNumbersCallbackConfiguration.Update(hmacSecret);
         }
 
         [Then(@"the response contains the updated project's callback configuration")]

--- a/tests/Sinch.Tests/Numbers/CallbackConfigurationTests.cs
+++ b/tests/Sinch.Tests/Numbers/CallbackConfigurationTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Newtonsoft.Json;
 using RichardSzalay.MockHttp;
-using Sinch.Numbers.Callbacks;
+using Sinch.Numbers.CallbackConfiguration;
 using Xunit;
 
 namespace Sinch.Tests.Numbers
@@ -19,7 +19,7 @@ namespace Sinch.Tests.Numbers
                 .WithHeaders("Authorization", $"Bearer {Token}")
                 .Respond("application/json", Helpers.LoadResources("Numbers/CallbackConfigurationResponse.json"));
 
-            var response = await Numbers.Callbacks.Get();
+            var response = await Numbers.CallbackConfiguration.Get();
 
             response.Should().BeEquivalentTo(new CallbackConfiguration()
             {
@@ -40,7 +40,7 @@ namespace Sinch.Tests.Numbers
                 }))
                 .Respond("application/json", Helpers.LoadResources("Numbers/CallbackConfigurationResponse.json"));
 
-            var response = await Numbers.Callbacks.Update("HMAC value");
+            var response = await Numbers.CallbackConfiguration.Update("HMAC value");
 
             response.Should().BeEquivalentTo(new CallbackConfiguration()
             {
@@ -63,7 +63,7 @@ namespace Sinch.Tests.Numbers
                 }))
                 .Respond("application/json", Helpers.LoadResources("Numbers/CallbackConfigurationResponse.json"));
 
-            var responseOp = () => Numbers.Callbacks.Update(hmacSecret);
+            var responseOp = () => Numbers.CallbackConfiguration.Update(hmacSecret);
 
             await responseOp.Should().ThrowAsync<ArgumentNullException>();
         }


### PR DESCRIPTION
## Summary

The **Numbers** currently exposes callback related functionality via `Callbacks`. For V2.0, this should be renamed to `CallbackConfiguration` to align with the other SDK’s naming conventions.