### PR TITLE
Store SDK version within repository

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 0.1.2
+next-version: 2.0.0
 branches:
   main:
     tag: 'alpha'

--- a/src/Sinch/Sinch.csproj
+++ b/src/Sinch/Sinch.csproj
@@ -6,7 +6,7 @@
         <RepositoryUrl>https://github.com/sinch/sinch-sdk-dotnet</RepositoryUrl>
         <Version>2.0.0</Version>
         <Title>Sinch</Title>
-        <Authors>Volodymyr Lisovskyi</Authors>
+        <Authors>Volodymyr Lisovskyi, Razvan Predescu</Authors>
         <Description>Sinch REST API SDK to work with sms, messaging, numbers, verification and more.</Description>
         <PackageProjectUrl>https://developers.sinch.com/</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>

--- a/src/Sinch/Sinch.csproj
+++ b/src/Sinch/Sinch.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <RepositoryUrl>https://github.com/sinch/sinch-sdk-dotnet</RepositoryUrl>
-        <Version>0.1.0</Version>
+        <Version>2.0.0</Version>
         <Title>Sinch</Title>
         <Authors>Volodymyr Lisovskyi</Authors>
         <Description>Sinch REST API SDK to work with sms, messaging, numbers, verification and more.</Description>

--- a/src/Sinch/Sinch.csproj
+++ b/src/Sinch/Sinch.csproj
@@ -6,7 +6,7 @@
         <RepositoryUrl>https://github.com/sinch/sinch-sdk-dotnet</RepositoryUrl>
         <Version>2.0.0</Version>
         <Title>Sinch</Title>
-        <Authors>Volodymyr Lisovskyi, Razvan Predescu</Authors>
+        <Authors>Razvan Predescu</Authors>
         <Description>Sinch REST API SDK to work with sms, messaging, numbers, verification and more.</Description>
         <PackageProjectUrl>https://developers.sinch.com/</PackageProjectUrl>
         <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
## Summary

The .NET SDK version in `AssemblyInfo.cs` has two issues:

Incorrect version format: displays 4 digits (e.g., 0.1.0.0) instead of 3 digits (e.g., 2.0.0) which is the standard format used by Sinch SDKs

Wrong version in repository: the version is not updated to match the current release (2.0.0), causing users who clone the repository to report incorrect SDK version in logs and User-Agent headers.

While the official NuGet package has the correct version, local builds from the repository source will log activity with an incorrect version.