### PR TITLE
Schedule provisioning with strongly-typed failure error codes

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -346,7 +346,7 @@ Version 1.*:
 using Sinch.Numbers;
 
 var scheduledProvisioning = activeNumber.SmsConfiguration?.ScheduledProvisioning;
-if (scheduledProvisioning?.ErrorCodes?.Contains("SMS_PROVISIONING_FAILED"))
+if (scheduledProvisioning?.ErrorCodes?.Contains("CAMPAIGN_NOT_AVAILABLE"))
 {
     // handle error
 }

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -14,6 +14,7 @@
 - [Removed obsolete UrlMessage and CallMessage constructors](#removed-obsolete-urlmessage-and-callmessage-constructors)
 - [FaxRegion moved from SinchOptions to SinchFaxConfiguration](#faxregion-moved-from-sinchoptions-to-sinchfaxconfiguration)
 - [Numbers API: Callbacks renamed to CallbackConfiguration](#callbacks-renamed-to-callbackconfiguration)
+- [Numbers API: ScheduledProvisioning.ErrorCodes type changed to IList\<FailureCode\>](#scheduledprovisioningerrorcodes-type-changed-to-ilistfailurecode)
 
 ## Initialize `SinchClient` with unified credentials:
 
@@ -335,3 +336,31 @@ Version 2.*:
 ```csharp
 var callbackConfiguration = sinchClient.Numbers.CallbackConfiguration;
 ```
+
+## ScheduledProvisioning.ErrorCodes type changed to IList\<FailureCode\>
+
+The `ErrorCodes` property on `ScheduledProvisioning` has been changed from `List<string>?` to `IList<FailureCode>?`.
+
+Version 1.*:
+```csharp
+using Sinch.Numbers;
+
+var scheduledProvisioning = activeNumber.SmsConfiguration?.ScheduledProvisioning;
+if (scheduledProvisioning?.ErrorCodes?.Contains("SMS_PROVISIONING_FAILED"))
+{
+    // handle error
+}
+```
+
+Version 2.*:
+```csharp
+using Sinch.Numbers;
+using Sinch.Numbers.Hooks;
+
+var scheduledProvisioning = activeNumber.SmsConfiguration?.ScheduledProvisioning;
+if (scheduledProvisioning?.ErrorCodes?.Contains(FailureCode.CampaignNotAvailable))
+{
+    // handle error
+}
+```
+

--- a/src/Sinch/Numbers/FailureCode.cs
+++ b/src/Sinch/Numbers/FailureCode.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
 using Sinch.Core;
 
-namespace Sinch.Numbers.Hooks
+namespace Sinch.Numbers
 {
     /// <summary>
     ///     Represents the failure code options.

--- a/src/Sinch/Numbers/ScheduledProvisioning.cs
+++ b/src/Sinch/Numbers/ScheduledProvisioning.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Sinch.Numbers.Hooks;
 
 namespace Sinch.Numbers
 {

--- a/src/Sinch/Numbers/ScheduledProvisioning.cs
+++ b/src/Sinch/Numbers/ScheduledProvisioning.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Sinch.Numbers.Hooks;
 
 namespace Sinch.Numbers
 {
@@ -26,8 +27,7 @@ namespace Sinch.Numbers
         ///     The provisioning status codes are found
         ///     <see href="https://developers.sinch.com/docs/numbers/api-reference/error-codes/provisioning-errors/">here</see>.
         /// </summary>
-        // TODO?: provide error codes in enum
-        public List<string>? ErrorCodes { get; set; }
+        public IList<FailureCode>? ErrorCodes { get; set; }
 
         /// <summary>
         ///     Timestamp when the status was last updated.

--- a/tests/Sinch.Tests.Features/Numbers/NumbersService.cs
+++ b/tests/Sinch.Tests.Features/Numbers/NumbersService.cs
@@ -14,7 +14,6 @@ using Sinch.Numbers.Available;
 using Sinch.Numbers.Available.List;
 using Sinch.Numbers.Available.Rent;
 using Sinch.Numbers.Available.RentAny;
-using Sinch.Numbers.Hooks;
 using Sinch.Numbers.VoiceConfigurations;
 
 namespace Sinch.Tests.Features.Numbers

--- a/tests/Sinch.Tests.Features/Numbers/NumbersService.cs
+++ b/tests/Sinch.Tests.Features/Numbers/NumbersService.cs
@@ -14,6 +14,7 @@ using Sinch.Numbers.Available;
 using Sinch.Numbers.Available.List;
 using Sinch.Numbers.Available.Rent;
 using Sinch.Numbers.Available.RentAny;
+using Sinch.Numbers.Hooks;
 using Sinch.Numbers.VoiceConfigurations;
 
 namespace Sinch.Tests.Features.Numbers
@@ -83,7 +84,7 @@ namespace Sinch.Tests.Features.Numbers
                     {
                         ServicePlanId = "SingingMooseSociety",
                         CampaignId = string.Empty,
-                        ErrorCodes = [],
+                        ErrorCodes = new List<FailureCode>(),
                         Status = ProvisioningStatus.Waiting,
                         LastUpdatedTime = Helpers.ParseUtc("2024-06-06T20:02:20.432220Z")
                     }
@@ -248,7 +249,7 @@ namespace Sinch.Tests.Features.Numbers
                         Status = ProvisioningStatus.Waiting,
                         LastUpdatedTime = Helpers.ParseUtc("2024-06-06T14:42:42.596223Z"),
                         CampaignId = "",
-                        ErrorCodes = new List<string>()
+                        ErrorCodes = new List<FailureCode>()
                     },
                     CampaignId = ""
                 },
@@ -368,7 +369,7 @@ namespace Sinch.Tests.Features.Numbers
             number.SmsConfiguration!.ServicePlanId.Should().BeEmpty();
             number.SmsConfiguration!.ScheduledProvisioning!.Status.Should().Be(ProvisioningStatus.Failed);
             number.SmsConfiguration!.ScheduledProvisioning.ErrorCodes.Should()
-                .BeEquivalentTo(new List<string>() { "SMS_PROVISIONING_FAILED" });
+                .BeEquivalentTo(new List<FailureCode>() { new("SMS_PROVISIONING_FAILED") });
         }
 
         [Then(@"the response contains an error about the number ""(.*)"" not being a rented number")]

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -11,6 +11,7 @@ using Sinch.Numbers;
 using Sinch.Numbers.Active;
 using Sinch.Numbers.Active.List;
 using Sinch.Numbers.Active.Update;
+using Sinch.Numbers.Hooks;
 using Sinch.Numbers.VoiceConfigurations;
 using Xunit;
 
@@ -235,7 +236,7 @@ namespace Sinch.Tests.Numbers
                     CampaignId = "campaign id from scheduled",
                     Status = ProvisioningStatus.Unspecified,
                     LastUpdatedTime = Helpers.ParseUtc("2023-09-25T12:08:02.115Z"),
-                    ErrorCodes = new List<string> { "ERROR_CODE_UNSPECIFIED" }
+                    ErrorCodes = new List<FailureCode> { new("ERROR_CODE_UNSPECIFIED") }
                 }
             },
             VoiceConfiguration = new VoiceRtcConfiguration
@@ -259,6 +260,49 @@ namespace Sinch.Tests.Numbers
             var json = Helpers.LoadResources("Numbers/Active/ActiveNumber.json");
             var activeNumber = JsonSerializer.Deserialize<ActiveNumber>(json, Numbers.JsonSerializerOptions);
             activeNumber.Should().BeOfType<ActiveNumber>().And.BeEquivalentTo(_activeNumber);
+        }
+
+        [Fact]
+        public void DeserializeScheduledProvisioningWithErrorCodes()
+        {
+            var json = Helpers.LoadResources("Numbers/ScheduledProvisioningWithErrorCodes.json");
+
+            var result = JsonSerializer.Deserialize<ScheduledProvisioning>(json, Numbers.JsonSerializerOptions);
+
+            result.Should().BeEquivalentTo(new ScheduledProvisioning
+            {
+                ServicePlanId = "test-service-plan-id",
+                CampaignId = "test-campaign-id",
+                Status = ProvisioningStatus.Failed,
+                LastUpdatedTime = Helpers.ParseUtc("2024-01-15T10:30:00.000Z"),
+                ErrorCodes = new List<FailureCode>
+                {
+                    FailureCode.CampaignNotAvailable,
+                    new("CUSTOM_ERROR_CODE")
+                }
+            });
+        }
+
+        [Fact]
+        public void SerializeScheduledProvisioningWithErrorCodes()
+        {
+            var scheduledProvisioning = new ScheduledProvisioning
+            {
+                ServicePlanId = "test-service-plan-id",
+                CampaignId = "test-campaign-id",
+                Status = ProvisioningStatus.Failed,
+                LastUpdatedTime = Helpers.ParseUtc("2024-01-15T10:30:00.000Z"),
+                ErrorCodes = new List<FailureCode>
+                {
+                    FailureCode.CampaignNotAvailable,
+                    new("CUSTOM_ERROR_CODE")
+                }
+            };
+
+            var actual = JsonSerializer.Serialize(scheduledProvisioning, Numbers.JsonSerializerOptions);
+
+            var expected = Helpers.LoadResources("Numbers/ScheduledProvisioningWithErrorCodes.json");
+            Helpers.AssertJsonEqual(expected, actual);
         }
 
         [Fact]
@@ -286,7 +330,7 @@ namespace Sinch.Tests.Numbers
                         CampaignId = "campaign id from scheduled",
                         Status = ProvisioningStatus.Unspecified,
                         LastUpdatedTime = Helpers.ParseUtc("2023-09-25T12:08:02.115Z"),
-                        ErrorCodes = new List<string> { "ERROR_CODE_UNSPECIFIED" }
+                        ErrorCodes = new List<FailureCode> { new("ERROR_CODE_UNSPECIFIED") }
                     }
                 },
                 VoiceConfiguration = new VoiceRtcConfiguration
@@ -356,7 +400,7 @@ namespace Sinch.Tests.Numbers
                         CampaignId = "campaign id from scheduled",
                         Status = ProvisioningStatus.Unspecified,
                         LastUpdatedTime = Helpers.ParseUtc("2023-09-25T12:08:02.115Z"),
-                        ErrorCodes = new List<string> { "ERROR_CODE_UNSPECIFIED" }
+                        ErrorCodes = new List<FailureCode> { new("ERROR_CODE_UNSPECIFIED") }
                     }
                 },
                 VoiceConfiguration = new VoiceEstConfiguration
@@ -425,7 +469,7 @@ namespace Sinch.Tests.Numbers
                         CampaignId = "campaign id from scheduled",
                         Status = ProvisioningStatus.Unspecified,
                         LastUpdatedTime = Helpers.ParseUtc("2023-09-25T12:08:02.115Z"),
-                        ErrorCodes = new List<string> { "ERROR_CODE_UNSPECIFIED" }
+                        ErrorCodes = new List<FailureCode> { new("ERROR_CODE_UNSPECIFIED") }
                     }
                 },
                 VoiceConfiguration = new VoiceFaxConfiguration

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -11,7 +11,6 @@ using Sinch.Numbers;
 using Sinch.Numbers.Active;
 using Sinch.Numbers.Active.List;
 using Sinch.Numbers.Active.Update;
-using Sinch.Numbers.Hooks;
 using Sinch.Numbers.VoiceConfigurations;
 using Xunit;
 

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -283,27 +283,6 @@ namespace Sinch.Tests.Numbers
             });
         }
 
-        [Fact]
-        public void SerializeScheduledProvisioningWithErrorCodes()
-        {
-            var scheduledProvisioning = new ScheduledProvisioning
-            {
-                ServicePlanId = "test-service-plan-id",
-                CampaignId = "test-campaign-id",
-                Status = ProvisioningStatus.Failed,
-                LastUpdatedTime = Helpers.ParseUtc("2024-01-15T10:30:00.000Z"),
-                ErrorCodes = new List<FailureCode>
-                {
-                    FailureCode.CampaignNotAvailable,
-                    new("CUSTOM_ERROR_CODE")
-                }
-            };
-
-            var actual = JsonSerializer.Serialize(scheduledProvisioning, Numbers.JsonSerializerOptions);
-
-            var expected = Helpers.LoadResources("Numbers/ScheduledProvisioningWithErrorCodes.json");
-            Helpers.AssertJsonEqual(expected, actual);
-        }
 
         [Fact]
         public async Task UpdateActiveNumber_WithVoiceRtcConfiguration()

--- a/tests/Sinch.Tests/Numbers/HooksTests.cs
+++ b/tests/Sinch.Tests/Numbers/HooksTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using FluentAssertions;
+using Sinch.Numbers;
 using Sinch.Numbers.Hooks;
 using Xunit;
 

--- a/tests/Sinch.Tests/Resources/Numbers/ScheduledProvisioningWithErrorCodes.json
+++ b/tests/Sinch.Tests/Resources/Numbers/ScheduledProvisioningWithErrorCodes.json
@@ -1,0 +1,11 @@
+﻿{
+  "servicePlanId": "test-service-plan-id",
+  "campaignId": "test-campaign-id",
+  "status": "FAILED",
+  "lastUpdatedTime": "2024-01-15T10:30:00.000Z",
+  "errorCodes": [
+    "CAMPAIGN_NOT_AVAILABLE",
+    "CUSTOM_ERROR_CODE"
+  ]
+}
+


### PR DESCRIPTION
## Summary

This PR changes the `ErrorCodes` property on `ScheduledProvisioning` from `List<string>?` to `IList<FailureCode>?` to provide strongly-typed error codes instead of raw strings.
