### PR TITLE
OAS Sync Numbers - Optional active numbers query params

### DIFF
--- a/examples/snippets/numbers/List/List.cs
+++ b/examples/snippets/numbers/List/List.cs
@@ -8,19 +8,11 @@
 
 using Sinch;
 using Sinch.Core;
-using Sinch.Numbers;
-using Sinch.Numbers.Active.List;
 using Sinch.Snippets.Shared;
 
 var projectId = ConfigurationHelper.GetProjectId() ?? "MY_PROJECT_ID";
 var keyId = ConfigurationHelper.GetKeyId() ?? "MY_KEY_ID";
 var keySecret = ConfigurationHelper.GetKeySecret() ?? "MY_KEY_SECRET";
-
-var request = new ListActiveNumbersRequest
-{
-    RegionCode = "US",
-    Type = Types.Local
-};
 
 var client = new SinchClient(new SinchClientConfiguration()
 {
@@ -34,6 +26,6 @@ var client = new SinchClient(new SinchClientConfiguration()
 
 Console.WriteLine("Listing active numbers");
 
-var response = await client.Numbers.List(request);
+var response = await client.Numbers.List();
 
 Console.WriteLine($"Response: {response.ToPrettyString()}");

--- a/src/Sinch/Numbers/Active.cs
+++ b/src/Sinch/Numbers/Active.cs
@@ -15,20 +15,29 @@ namespace Sinch.Numbers
     internal interface ISinchNumbersActive
     {
         /// <summary>
-        ///     Lists all virtual numbers for a project.<br /><br />
+        ///     Lists all virtual numbers for a project with optional filtering.
         ///     For additional info, see:
         ///     <see
         ///         href="https://developers.sinch.com/docs/numbers/api-reference/numbers/tag/Active-Number/#tag/Active-Number/operation/NumberService_ListActiveNumbers">
         ///         Documentation
         ///     </see>
         /// </summary>
-        /// <param name="request"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="request">Optional filter parameters such as region code, number type, capability, etc.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="ListActiveNumbersResponse"/> containing the matching active numbers.</returns>
         Task<ListActiveNumbersResponse> List(ListActiveNumbersRequest request,
             CancellationToken cancellationToken = default);
 
-        /// <inheritdoc cref="List(ListActiveNumbersRequest, CancellationToken)" />
+        /// <summary>
+        ///     Lists all virtual numbers for a project without any filters.
+        ///     For additional info, see:
+        ///     <see
+        ///         href="https://developers.sinch.com/docs/numbers/api-reference/numbers/tag/Active-Number/#tag/Active-Number/operation/NumberService_ListActiveNumbers">
+        ///         Documentation
+        ///     </see>
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="ListActiveNumbersResponse"/> containing all active numbers.</returns>
         Task<ListActiveNumbersResponse> List(CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -47,8 +56,8 @@ namespace Sinch.Numbers
         ///     <see href="https://community.sinch.com/t5/Glossary/E-164/ta-p/7537">E.164</see> format with leading +.
         /// </param>
         /// <param name="request">A request object</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The updated <see cref="ActiveNumber"/>.</returns>
         Task<ActiveNumber> Update(string phoneNumber,
             UpdateActiveNumberRequest request, CancellationToken cancellationToken = default);
 
@@ -56,8 +65,8 @@ namespace Sinch.Numbers
         ///     Get an information about a number
         /// </summary>
         /// <param name="phoneNumber">Number to get info about</param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The <see cref="ActiveNumber"/> details.</returns>
         Task<ActiveNumber> Get(string phoneNumber,
             CancellationToken cancellationToken = default);
 
@@ -69,15 +78,35 @@ namespace Sinch.Numbers
         ///     format with leading +.
         ///     <example>+12025550134</example>
         /// </param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>The released <see cref="ActiveNumber"/>.</returns>
         Task<ActiveNumber> Release(
             string phoneNumber, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        ///     Lists all virtual numbers for a project with optional filtering, automatically iterating over all pages.<br /><br />
+        ///     For additional info, see:
+        ///     <see
+        ///         href="https://developers.sinch.com/docs/numbers/api-reference/numbers/tag/Active-Number/#tag/Active-Number/operation/NumberService_ListActiveNumbers">
+        ///         Documentation
+        ///     </see>
+        /// </summary>
+        /// <param name="request">Optional filter parameters such as region code, number type, capability, etc.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>An async sequence of <see cref="ActiveNumber"/> items across all pages.</returns>
         IAsyncEnumerable<ActiveNumber> ListAuto(ListActiveNumbersRequest request,
             CancellationToken cancellationToken = default);
 
-        /// <inheritdoc cref="ListAuto(ListActiveNumbersRequest, CancellationToken)" />
+        /// <summary>
+        ///     Lists all virtual numbers for a project without any filters, automatically iterating over all pages.<br /><br />
+        ///     For additional info, see:
+        ///     <see
+        ///         href="https://developers.sinch.com/docs/numbers/api-reference/numbers/tag/Active-Number/#tag/Active-Number/operation/NumberService_ListActiveNumbers">
+        ///         Documentation
+        ///     </see>
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>An async sequence of <see cref="ActiveNumber"/> items across all pages.</returns>
         IAsyncEnumerable<ActiveNumber> ListAuto(CancellationToken cancellationToken = default);
     }
 

--- a/src/Sinch/Numbers/Active.cs
+++ b/src/Sinch/Numbers/Active.cs
@@ -97,7 +97,7 @@ namespace Sinch.Numbers
         {
             _logger?.LogDebug("Fetching active numbers {request}", request);
             var queryString = request.GetQueryString();
-            var query = queryString.Length > 0 ? "?" + queryString : string.Empty;
+            var query = queryString.Length > 0 ? $"?{queryString}" : string.Empty;
             var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{query}");
             return _http.Send<ListActiveNumbersResponse>(uri, HttpMethod.Get, cancellationToken);
         }
@@ -110,7 +110,7 @@ namespace Sinch.Numbers
             do
             {
                 var queryString = request.GetQueryString();
-                var query = queryString.Length > 0 ? "?" + queryString : string.Empty;
+                var query = queryString.Length > 0 ? $"?{queryString}" : string.Empty;
                 var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{query}");
                 var response = await _http.Send<ListActiveNumbersResponse>(uri, HttpMethod.Get, cancellationToken);
                 request.PageToken = response.NextPageToken;

--- a/src/Sinch/Numbers/Active.cs
+++ b/src/Sinch/Numbers/Active.cs
@@ -97,7 +97,8 @@ namespace Sinch.Numbers
         {
             _logger?.LogDebug("Fetching active numbers {request}", request);
             var queryString = request.GetQueryString();
-            var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{(queryString.Length > 0 ? "?" + queryString : string.Empty)}");
+            var query = queryString.Length > 0 ? "?" + queryString : string.Empty;
+            var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{query}");
             return _http.Send<ListActiveNumbersResponse>(uri, HttpMethod.Get, cancellationToken);
         }
 
@@ -109,7 +110,8 @@ namespace Sinch.Numbers
             do
             {
                 var queryString = request.GetQueryString();
-                var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{(queryString.Length > 0 ? "?" + queryString : string.Empty)}");
+                var query = queryString.Length > 0 ? "?" + queryString : string.Empty;
+                var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{query}");
                 var response = await _http.Send<ListActiveNumbersResponse>(uri, HttpMethod.Get, cancellationToken);
                 request.PageToken = response.NextPageToken;
                 foreach (var activeNumber in response.ActiveNumbers)

--- a/src/Sinch/Numbers/Active.cs
+++ b/src/Sinch/Numbers/Active.cs
@@ -96,7 +96,8 @@ namespace Sinch.Numbers
             CancellationToken cancellationToken = default)
         {
             _logger?.LogDebug("Fetching active numbers {request}", request);
-            var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers?{request.GetQueryString()}");
+            var queryString = request.GetQueryString();
+            var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{(queryString.Length > 0 ? "?" + queryString : string.Empty)}");
             return _http.Send<ListActiveNumbersResponse>(uri, HttpMethod.Get, cancellationToken);
         }
 
@@ -107,7 +108,8 @@ namespace Sinch.Numbers
             _logger?.LogDebug("Fetching active numbers {request}", request);
             do
             {
-                var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers?{request.GetQueryString()}");
+                var queryString = request.GetQueryString();
+                var uri = new Uri(_baseAddress, $"v1/projects/{_projectId}/activeNumbers{(queryString.Length > 0 ? "?" + queryString : string.Empty)}");
                 var response = await _http.Send<ListActiveNumbersResponse>(uri, HttpMethod.Get, cancellationToken);
                 request.PageToken = response.NextPageToken;
                 foreach (var activeNumber in response.ActiveNumbers)

--- a/src/Sinch/Numbers/Active.cs
+++ b/src/Sinch/Numbers/Active.cs
@@ -28,6 +28,9 @@ namespace Sinch.Numbers
         Task<ListActiveNumbersResponse> List(ListActiveNumbersRequest request,
             CancellationToken cancellationToken = default);
 
+        /// <inheritdoc cref="List(ListActiveNumbersRequest, CancellationToken)" />
+        Task<ListActiveNumbersResponse> List(CancellationToken cancellationToken = default);
+
         /// <summary>
         ///     Update a virtual phone number.
         ///     For example: you can move a number between different SMS services and give it a new, friendly name.
@@ -73,6 +76,9 @@ namespace Sinch.Numbers
 
         IAsyncEnumerable<ActiveNumber> ListAuto(ListActiveNumbersRequest request,
             CancellationToken cancellationToken = default);
+
+        /// <inheritdoc cref="ListAuto(ListActiveNumbersRequest, CancellationToken)" />
+        IAsyncEnumerable<ActiveNumber> ListAuto(CancellationToken cancellationToken = default);
     }
 
     internal sealed class ActiveNumbers : ISinchNumbersActive
@@ -103,6 +109,12 @@ namespace Sinch.Numbers
         }
 
         /// <inheritdoc />
+        public Task<ListActiveNumbersResponse> List(CancellationToken cancellationToken = default)
+        {
+            return List(new ListActiveNumbersRequest(), cancellationToken);
+        }
+
+        /// <inheritdoc />
         public async IAsyncEnumerable<ActiveNumber> ListAuto(ListActiveNumbersRequest request,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
@@ -119,6 +131,12 @@ namespace Sinch.Numbers
                     yield return activeNumber;
                 }
             } while (!string.IsNullOrEmpty(request.PageToken));
+        }
+
+        /// <inheritdoc />
+        public IAsyncEnumerable<ActiveNumber> ListAuto(CancellationToken cancellationToken = default)
+        {
+            return ListAuto(new ListActiveNumbersRequest(), cancellationToken);
         }
 
         /// <inheritdoc />

--- a/src/Sinch/Numbers/Active/List/ListActiveNumbersRequest.cs
+++ b/src/Sinch/Numbers/Active/List/ListActiveNumbersRequest.cs
@@ -10,15 +10,12 @@ namespace Sinch.Numbers.Active.List
         ///     Region code to filter by. ISO 3166-1 alpha-2 country code of the phone number. <br /><br />
         ///     <example>US, GB or SE.</example>
         /// </summary>
-
-        public required string RegionCode { get; set; }
-
+        public string? RegionCode { get; set; }
 
         /// <summary>
         ///     Number type to filter by.
         /// </summary>
-
-        public required Types Type { get; set; }
+        public Types? Type { get; set; }
 
 
 
@@ -49,11 +46,13 @@ namespace Sinch.Numbers.Active.List
 
         internal string GetQueryString()
         {
-            var dict = new List<KeyValuePair<string, string>>
-            {
-                new("regionCode", RegionCode),
-                new("type", Type.Value)
-            };
+            var dict = new List<KeyValuePair<string, string>>();
+
+            if (RegionCode != null)
+                dict.Add(new KeyValuePair<string, string>("regionCode", RegionCode));
+
+            if (Type != null)
+                dict.Add(new KeyValuePair<string, string>("type", Type.Value));
 
             if (NumberPattern != null)
             {

--- a/src/Sinch/Numbers/Numbers.cs
+++ b/src/Sinch/Numbers/Numbers.cs
@@ -59,13 +59,19 @@ namespace Sinch.Numbers
         Task<ActiveNumber> Update(string phoneNumber,
             UpdateActiveNumberRequest request, CancellationToken cancellationToken = default);
 
-        /// <inheritdoc cref="ISinchNumbersActive.List" />
+        /// <inheritdoc cref="ISinchNumbersActive.List(ListActiveNumbersRequest, CancellationToken)" />
         Task<ListActiveNumbersResponse> List(ListActiveNumbersRequest request,
             CancellationToken cancellationToken = default);
 
-        /// <inheritdoc cref="ISinchNumbersActive.ListAuto" />
+        /// <inheritdoc cref="ISinchNumbersActive.List(CancellationToken)" />
+        Task<ListActiveNumbersResponse> List(CancellationToken cancellationToken = default);
+
+        /// <inheritdoc cref="ISinchNumbersActive.ListAuto(ListActiveNumbersRequest, CancellationToken)" />
         IAsyncEnumerable<ActiveNumber> ListAuto(ListActiveNumbersRequest request,
             CancellationToken cancellationToken = default);
+
+        /// <inheritdoc cref="ISinchNumbersActive.ListAuto(CancellationToken)" />
+        IAsyncEnumerable<ActiveNumber> ListAuto(CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     For internal use, JsonSerializerOption to be utilized for serialization and deserialization of all Numbers models
@@ -167,10 +173,22 @@ namespace Sinch.Numbers
         }
 
         /// <inheritdoc />
+        public Task<ListActiveNumbersResponse> List(CancellationToken cancellationToken = default)
+        {
+            return _activeNumbers.List(cancellationToken);
+        }
+
+        /// <inheritdoc />
         public IAsyncEnumerable<ActiveNumber> ListAuto(ListActiveNumbersRequest request,
             CancellationToken cancellationToken = default)
         {
             return _activeNumbers.ListAuto(request, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public IAsyncEnumerable<ActiveNumber> ListAuto(CancellationToken cancellationToken = default)
+        {
+            return _activeNumbers.ListAuto(cancellationToken);
         }
 
         public JsonSerializerOptions JsonSerializerOptions { get; }

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -91,6 +91,29 @@ namespace Sinch.Tests.Numbers
         }
 
         [Fact]
+        public async Task ListParameterless()
+        {
+            HttpMessageHandlerMock
+                .When(HttpMethod.Get,
+                    $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers")
+                .WithHeaders("Authorization", $"Bearer {Token}")
+                .Respond(HttpStatusCode.OK, JsonContent.Create(new
+                {
+                    activeNumbers = new[]
+                    {
+                        TestData.ActiveNumber
+                    },
+                    nextPageToken = string.Empty,
+                    totalSize = 1
+                }));
+
+            var response = await Numbers.List();
+
+            response.Should().NotBeNull();
+            response.ActiveNumbers.Should().HaveCount(1);
+        }
+
+        [Fact]
         public async Task ListWithFullParams()
         {
             var url = $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers?regionCode=US&type=LOCAL";

--- a/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
+++ b/tests/Sinch.Tests/Numbers/ActiveNumberTests.cs
@@ -68,6 +68,29 @@ namespace Sinch.Tests.Numbers
         }
 
         [Fact]
+        public async Task ListWithNoFilters()
+        {
+            HttpMessageHandlerMock
+                .When(HttpMethod.Get,
+                    $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers")
+                .WithHeaders("Authorization", $"Bearer {Token}")
+                .Respond(HttpStatusCode.OK, JsonContent.Create(new
+                {
+                    activeNumbers = new[]
+                    {
+                        TestData.ActiveNumber
+                    },
+                    nextPageToken = string.Empty,
+                    totalSize = 1
+                }));
+
+            var response = await Numbers.List(new ListActiveNumbersRequest());
+
+            response.Should().NotBeNull();
+            response.ActiveNumbers.Should().HaveCount(1);
+        }
+
+        [Fact]
         public async Task ListWithFullParams()
         {
             var url = $"https://numbers.api.sinch.com/v1/projects/{ProjectId}/activeNumbers?regionCode=US&type=LOCAL";


### PR DESCRIPTION
### Summary

The /v1/projects/{projectId}/activeNumbers endpoint had `regionCode` and `type` query parameters changed from `required: true` to `required: false`.