### PR TITLE
fix: AppId and ProjectId are required

### DIFF
--- a/src/Sinch/Conversation/Hooks/CallbackEventBase.cs
+++ b/src/Sinch/Conversation/Hooks/CallbackEventBase.cs
@@ -10,7 +10,7 @@ namespace Sinch.Conversation.Hooks
         /// </summary>
         [JsonPropertyName("app_id")]
         public required string AppId { get; set; }
-        
+
         /// <summary>
         ///     Timestamp marking when the channel callback was accepted/received by the Conversation API.
         /// </summary>
@@ -28,13 +28,13 @@ namespace Sinch.Conversation.Hooks
         /// </summary>
         [JsonPropertyName("project_id")]
         public required string ProjectId { get; set; }
-        
+
         /// <summary>
         ///     Context-dependent metadata. Refer to specific callback&#39;s documentation for exact information provided.
         /// </summary>
         [JsonPropertyName("message_metadata")]
         public string? MessageMetadata { get; set; }
-        
+
         /// <summary>
         ///     The value provided in field correlation_id of a send message request.
         /// </summary>

--- a/src/Sinch/Conversation/Hooks/CallbackEventBase.cs
+++ b/src/Sinch/Conversation/Hooks/CallbackEventBase.cs
@@ -9,14 +9,13 @@ namespace Sinch.Conversation.Hooks
         ///     Id of the subscribed app.
         /// </summary>
         [JsonPropertyName("app_id")]
-        public string? AppId { get; set; }
-
+        public required string AppId { get; set; }
+        
         /// <summary>
         ///     Timestamp marking when the channel callback was accepted/received by the Conversation API.
         /// </summary>
         [JsonPropertyName("accepted_time")]
         public DateTime? AcceptedTime { get; set; }
-
 
         /// <summary>
         ///     Timestamp of the event as provided by the underlying channels.
@@ -28,16 +27,14 @@ namespace Sinch.Conversation.Hooks
         ///     The project ID of the app which has subscribed for the callback.
         /// </summary>
         [JsonPropertyName("project_id")]
-        public string? ProjectId { get; set; }
-
-
+        public required string ProjectId { get; set; }
+        
         /// <summary>
         ///     Context-dependent metadata. Refer to specific callback&#39;s documentation for exact information provided.
         /// </summary>
         [JsonPropertyName("message_metadata")]
         public string? MessageMetadata { get; set; }
-
-
+        
         /// <summary>
         ///     The value provided in field correlation_id of a send message request.
         /// </summary>


### PR DESCRIPTION
### Summary

CallbackEventBase has new required properties:
- AppId
- ProjectId