### PR TITLE
SinchEvents - Redesign of webhooks and callback configuration

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -65,6 +65,7 @@
 - [Fax API: CallbackUrl renamed to EventDestinationTarget](#fax-api-callbackurl-renamed-to-eventdestinationtarget)
 - [Fax API: WebhookContentType renamed to EventDestinationContentType on ServiceBase](#fax-api-webhookcontenttype-renamed-to-eventdestinationcontenttype-on-servicebase)
 - [Fax API: IncomingWebhookUrl renamed to IncomingEventDestinationTarget on ServiceBase](#fax-api-incomingwebhookurl-renamed-to-incomingeventdestinationtarget-on-servicebase)
+- [Conversation API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#conversation-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 
 ## .NET Framework Support
 
@@ -1124,7 +1125,7 @@ var isValid = sinch.Conversation.Webhooks.ValidateAuthenticationHeader(headers, 
 
 Version 2.*:
 ```csharp
-var isValid = sinch.Conversation.EventDestinations.ValidateAuthenticationHeader(headers, rawBody, secret);
+var isValid = sinch.Conversation.SinchEvents.ValidateAuthenticationHeader(headers, rawBody, secret);
 ```
 
 ## Conversation API: Webhooks ValidateAuthenticationHeader no longer accepts StringValues headers
@@ -1149,7 +1150,7 @@ var headers = new Dictionary<string, string>
     ["x-sinch-webhook-signature"] = signature
 };
 
-var isValid = sinch.Conversation.EventDestinations.ValidateAuthenticationHeader(headers, rawBody, secret);
+var isValid = sinch.Conversation.SinchEvents.ValidateAuthenticationHeader(headers, rawBody, secret);
 
 // Option B: multi-value headers (e.g. from HttpContext.Request.Headers)
 IReadOnlyDictionary<string, IEnumerable<string>> headers = new Dictionary<string, IEnumerable<string>>
@@ -1157,7 +1158,7 @@ IReadOnlyDictionary<string, IEnumerable<string>> headers = new Dictionary<string
     ["x-sinch-webhook-signature"] = new[] { signature }
 };
 
-var isValid = sinch.Conversation.EventDestinations.ValidateAuthenticationHeader(headers, rawBody, secret);
+var isValid = sinch.Conversation.SinchEvents.ValidateAuthenticationHeader(headers, rawBody, secret);
 ```
 
 ## Conversation API: Webhooks ParseEvent no longer accepts JsonNode
@@ -1172,7 +1173,7 @@ var callback = sinch.Conversation.Webhooks.ParseEvent(node!);
 
 Version 2.*:
 ```csharp
-var callback = sinch.Conversation.EventDestinations.ParseEvent(rawBody);
+var callback = sinch.Conversation.SinchEvents.ParseEvent(rawBody);
 ```
 
 ## Conversation API: Webhooks renamed to EventDestinations
@@ -1658,5 +1659,23 @@ var request = new CreateServiceRequest
 {
     IncomingEventDestinationTarget = "https://my.server/incoming"
 };
+```
+
+## Conversation API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain
+
+`ParseEvent` and `ValidateAuthenticationHeader` have moved from `ISinchConversationWebhooks` (V1) to the new `IConversationSinchEvents` sub-domain, accessible as `sinch.Conversation.SinchEvents`.
+
+Version 1.*:
+```csharp
+var parsed = sinch.Conversation.Webhooks.ParseEvent(rawBody);
+sinch.Conversation.Webhooks.ValidateAuthenticationHeader(headers, rawBody, secret);
+```
+
+Version 2.*:
+```csharp
+using Sinch.Conversation.SinchEvents;
+
+var parsed = sinch.Conversation.SinchEvents.ParseEvent(rawBody);
+sinch.Conversation.SinchEvents.ValidateAuthenticationHeader(headers, rawBody, secret);
 ```
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -68,6 +68,8 @@
 - [Conversation API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#conversation-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 - [Numbers API: ValidateAuthenticationHeader moved to SinchEvents sub-domain](#numbers-api-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 - [Voice API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#voice-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
+- [SMS API: ValidateAuthenticationHeader headers parameter changed to IDictionary\<string,IEnumerable\<string\>\>](#sms-api-validateauthenticationheader-headers-parameter-changed-to-idictionarystrings-ienumerablestring)
+- [Fax API: ValidateAuthenticationHeader headers parameter changed to IDictionary\<string,IEnumerable\<string\>\>](#fax-api-validateauthenticationheader-headers-parameter-changed-to-idictionarystrings-ienumerablestring)
 - [Verification API: ValidateAuthenticationHeader moved to SinchEvents sub-domain](#verification-api-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 
 ## .NET Framework Support
@@ -1133,7 +1135,7 @@ var isValid = sinch.Conversation.SinchEvents.ValidateAuthenticationHeader(header
 
 ## Conversation API: Webhooks ValidateAuthenticationHeader no longer accepts StringValues headers
 
-`ISinchConversationWebhooks.ValidateAuthenticationHeader` no longer accepts `Dictionary<string, StringValues>`. Use either `IDictionary<string, string>` (single-value headers) or `IReadOnlyDictionary<string, IEnumerable<string>>` (multi-value headers).
+`ISinchConversationWebhooks.ValidateAuthenticationHeader` no longer accepts `Dictionary<string, StringValues>`. Use `IReadOnlyDictionary<string, IEnumerable<string>>` (multi-value headers, compatible with ASP.NET Core's `IHeaderDictionary`).
 
 Version 1.*:
 ```csharp
@@ -1147,15 +1149,7 @@ var isValid = sinch.Conversation.Webhooks.ValidateAuthenticationHeader(headers, 
 
 Version 2.*:
 ```csharp
-// Option A: single-value headers (e.g. from a plain dictionary)
-var headers = new Dictionary<string, string>
-{
-    ["x-sinch-webhook-signature"] = signature
-};
-
-var isValid = sinch.Conversation.SinchEvents.ValidateAuthenticationHeader(headers, rawBody, secret);
-
-// Option B: multi-value headers (e.g. from HttpContext.Request.Headers)
+// Multi-value headers (e.g. from HttpContext.Request.Headers)
 IReadOnlyDictionary<string, IEnumerable<string>> headers = new Dictionary<string, IEnumerable<string>>
 {
     ["x-sinch-webhook-signature"] = new[] { signature }
@@ -1496,6 +1490,46 @@ var requestEvent = JsonSerializer.Deserialize<VerificationRequestEvent>(json);
 Version 2.*:
 ```csharp
 var requestEvent = JsonSerializer.Deserialize<VerificationStartEvent>(json);
+```
+
+## SMS API: ValidateAuthenticationHeader headers parameter changed to IDictionary<string,IEnumerable<string>>
+
+`ISmsSinchEvents.ValidateAuthenticationHeader` now accepts `IDictionary<string, IEnumerable<string>>` instead of `IDictionary<string, string>`.
+
+Version 1.*:
+```csharp
+var headers = new Dictionary<string, string>
+{
+    ["x-sinch-webhook-signature"] = signature
+};
+
+var isValid = sinch.Sms.Webhooks.ValidateAuthenticationHeader(secret, headers, rawBody);
+```
+
+Version 2.*:
+```csharp
+IDictionary<string, IEnumerable<string>> headers = new Dictionary<string, IEnumerable<string>>
+{
+    ["x-sinch-webhook-signature"] = [signature]
+};
+
+var isValid = sinch.Sms.SinchEvents.ValidateAuthenticationHeader(secret, headers, rawBody);
+```
+
+## Fax API: ValidateAuthenticationHeader headers parameter changed to IDictionary<string,IEnumerable<string>>
+
+`IFaxSinchEvents.ValidateAuthenticationHeader` now accepts `IDictionary<string, IEnumerable<string>>` instead of `IDictionary<string, string>`.
+
+Version 1.*:
+```csharp
+var headers = new Dictionary<string, string> { ... };
+var isValid = sinch.Fax.SinchEvents.ValidateAuthenticationHeader(headers, rawBody);
+```
+
+Version 2.*:
+```csharp
+IDictionary<string, IEnumerable<string>> headers = new Dictionary<string, IEnumerable<string>> { ... };
+var isValid = sinch.Fax.SinchEvents.ValidateAuthenticationHeader(headers, rawBody);
 ```
 
 ## Verification API: ValidateAuthenticationHeader moved to SinchEvents sub-domain

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -66,6 +66,8 @@
 - [Fax API: WebhookContentType renamed to EventDestinationContentType on ServiceBase](#fax-api-webhookcontenttype-renamed-to-eventdestinationcontenttype-on-servicebase)
 - [Fax API: IncomingWebhookUrl renamed to IncomingEventDestinationTarget on ServiceBase](#fax-api-incomingwebhookurl-renamed-to-incomingeventdestinationtarget-on-servicebase)
 - [Conversation API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#conversation-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
+- [Numbers API: ValidateAuthenticationHeader moved to SinchEvents sub-domain](#numbers-api-validateauthenticationheader-moved-to-sinchevents-sub-domain)
+- [Voice API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#voice-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 
 ## .NET Framework Support
 
@@ -1392,7 +1394,7 @@ if (callbackEvent is UnsupportedCallbackEvent unsupported) { /* ... */ }
 
 Version 2.*:
 ```csharp
-IConversationSinchEvent sinchEvent = sinch.Conversation.EventDestinations.ParseEvent(rawBody);
+IConversationSinchEvent sinchEvent = sinch.Conversation.SinchEvents.ParseEvent(rawBody);
 if (sinchEvent is UnsupportedConversationSinchEvent unsupported) { /* ... */ }
 ```
 
@@ -1532,7 +1534,7 @@ switch (sinchEvent)
 
 Version 2.*:
 ```csharp
-VoiceSinchEvent sinchEvent = sinch.Voice.ParseEvent(rawBody);
+VoiceSinchEvent sinchEvent = sinch.Voice.SinchEvents.ParseEvent(rawBody);
 switch (sinchEvent)
 {
     case AnsweredCallEvent ace: /* ... */ break;
@@ -1677,5 +1679,39 @@ using Sinch.Conversation.SinchEvents;
 
 var parsed = sinch.Conversation.SinchEvents.ParseEvent(rawBody);
 sinch.Conversation.SinchEvents.ValidateAuthenticationHeader(headers, rawBody, secret);
+```
+
+## Numbers API: ValidateAuthenticationHeader moved to SinchEvents sub-domain
+
+`ValidateAuthenticationHeader` has been removed from `ISinchNumbers` and is now on the new `INumbersSinchEvents` sub-domain, accessible as `sinch.Numbers.SinchEvents`.
+
+Version 1.*:
+```csharp
+bool isValid = sinch.Numbers.ValidateAuthenticationHeader(hmacSecret, rawBody, signatureHeaderValue);
+```
+
+Version 2.*:
+```csharp
+using Sinch.Numbers.SinchEvents;
+
+bool isValid = sinch.Numbers.SinchEvents.ValidateAuthenticationHeader(hmacSecret, rawBody, signatureHeaderValue);
+```
+
+## Voice API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain
+
+`ParseEvent` and `ValidateAuthenticationHeader` have been removed from `ISinchVoiceClient` and are now on the new `IVoiceSinchEvents` sub-domain, accessible as `sinch.Voice.SinchEvents`.
+
+Version 1.*:
+```csharp
+VoiceSinchEvent sinchEvent = sinch.Voice.ParseEvent(rawBody);
+bool isValid = sinch.Voice.ValidateAuthenticationHeader(HttpMethod.Post, "/path", headers, rawBody);
+```
+
+Version 2.*:
+```csharp
+using Sinch.Voice.SinchEvents;
+
+VoiceSinchEvent sinchEvent = sinch.Voice.SinchEvents.ParseEvent(rawBody);
+bool isValid = sinch.Voice.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/path", headers, rawBody);
 ```
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -68,6 +68,7 @@
 - [Conversation API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#conversation-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 - [Numbers API: ValidateAuthenticationHeader moved to SinchEvents sub-domain](#numbers-api-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 - [Voice API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#voice-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
+- [Verification API: ValidateAuthenticationHeader moved to SinchEvents sub-domain](#verification-api-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 
 ## .NET Framework Support
 
@@ -1495,6 +1496,22 @@ var requestEvent = JsonSerializer.Deserialize<VerificationRequestEvent>(json);
 Version 2.*:
 ```csharp
 var requestEvent = JsonSerializer.Deserialize<VerificationStartEvent>(json);
+```
+
+## Verification API: ValidateAuthenticationHeader moved to SinchEvents sub-domain
+
+`ValidateAuthenticationHeader` has been removed from `ISinchVerificationClient` and is now on the new `IVerificationSinchEvents` sub-domain, accessible as `sinch.Verification.SinchEvents`.
+
+Version 1.*:
+```csharp
+bool isValid = sinch.Verification.ValidateAuthenticationHeader(HttpMethod.Post, "/path", headers, rawBody);
+```
+
+Version 2.*:
+```csharp
+using Sinch.Verification.SinchEvents;
+
+bool isValid = sinch.Verification.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/path", headers, rawBody);
 ```
 
 ## Voice API: Sinch.Voice.Hooks namespace renamed to Sinch.Voice.SinchEvents

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -68,6 +68,7 @@
 - [Conversation API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#conversation-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 - [Numbers API: ValidateAuthenticationHeader moved to SinchEvents sub-domain](#numbers-api-validateauthenticationheader-moved-to-sinchevents-sub-domain)
 - [Voice API: ParseEvent and ValidateAuthenticationHeader moved to SinchEvents sub-domain](#voice-api-parseevent-and-validateauthenticationheader-moved-to-sinchevents-sub-domain)
+- [Voice API: ParseEvent no longer accepts JsonNode](#voice-api-parseevent-no-longer-accepts-jsonnode)
 - [SMS API: ValidateAuthenticationHeader headers parameter changed to IDictionary\<string,IEnumerable\<string\>\>](#sms-api-validateauthenticationheader-headers-parameter-changed-to-idictionarystrings-ienumerablestring)
 - [Fax API: ValidateAuthenticationHeader headers parameter changed to IDictionary\<string,IEnumerable\<string\>\>](#fax-api-validateauthenticationheader-headers-parameter-changed-to-idictionarystrings-ienumerablestring)
 - [Verification API: ValidateAuthenticationHeader moved to SinchEvents sub-domain](#verification-api-validateauthenticationheader-moved-to-sinchevents-sub-domain)
@@ -1523,7 +1524,7 @@ var isValid = sinch.Sms.SinchEvents.ValidateAuthenticationHeader(secret, headers
 Version 1.*:
 ```csharp
 var headers = new Dictionary<string, string> { ... };
-var isValid = sinch.Fax.SinchEvents.ValidateAuthenticationHeader(headers, rawBody);
+var isValid = sinch.Fax.Webhooks.ValidateAuthenticationHeader(headers, rawBody);
 ```
 
 Version 2.*:
@@ -1764,5 +1765,20 @@ using Sinch.Voice.SinchEvents;
 
 VoiceSinchEvent sinchEvent = sinch.Voice.SinchEvents.ParseEvent(rawBody);
 bool isValid = sinch.Voice.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/path", headers, rawBody);
+```
+
+## Voice API: ParseEvent no longer accepts JsonNode
+
+`IVoiceSinchEvents.ParseEvent` now accepts only raw JSON strings or streams.
+
+Version 1.*:
+```csharp
+var node = JsonNode.Parse(rawBody);
+var sinchEvent = sinch.Voice.ParseEvent(node!);
+```
+
+Version 2.*:
+```csharp
+var sinchEvent = sinch.Voice.SinchEvents.ParseEvent(rawBody);
 ```
 

--- a/examples/templates/sinchevents/Program.cs
+++ b/examples/templates/sinchevents/Program.cs
@@ -28,7 +28,7 @@ builder.Services.AddSinchClient(() => new SinchClientConfiguration
     }
 });
 
-builder.Services.AddSingleton<ISmsSinchEvents>(sp => sp.GetRequiredService<ISinchClient>().Sms.SmsSinchEvents);
+builder.Services.AddSingleton<ISmsSinchEvents>(sp => sp.GetRequiredService<ISinchClient>().Sms.SinchEvents);
 
 var app = builder.Build();
 

--- a/examples/templates/sinchevents/Sms/SmsSinchEventsFilter.cs
+++ b/examples/templates/sinchevents/Sms/SmsSinchEventsFilter.cs
@@ -29,7 +29,10 @@ namespace SinchEvents.Template.Sms;
 
         var secret = configuration["Sinch:Sms:SinchEventSecret"] ?? string.Empty;
 
-        var headersDictionary = request.Headers.ToDictionary(h => h.Key, h => h.Value.ToString(), StringComparer.OrdinalIgnoreCase);
+        var headersDictionary = request.Headers.ToDictionary(
+            h => h.Key,
+            h => h.Value.AsEnumerable()!,
+            StringComparer.OrdinalIgnoreCase);
 
         if (!smsSinchEvents.ValidateAuthenticationHeader(secret, headersDictionary, body))
         {

--- a/src/Sinch/Conversation/EventDestinations/EventDestinations.cs
+++ b/src/Sinch/Conversation/EventDestinations/EventDestinations.cs
@@ -1,13 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
-using Sinch.Conversation.SinchEvents;
 using Sinch.Core;
 using Sinch.Logger;
 
@@ -64,40 +61,6 @@ namespace Sinch.Conversation.EventDestinations
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task Delete(string eventDestinationId, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        ///     Validates Sinch event request.
-        /// </summary>
-        /// <param name="headers">The Sinch event request headers as single-value entries.</param>
-        /// <param name="body">The Sinch event raw body, as received from the HTTP request.</param>
-        /// <param name="secret">The event destination secret used to generate the HMAC signature.</param>
-        /// <returns>True, if produced signature match with that of a header.</returns>
-        bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body, string secret);
-
-        /// <summary>
-        ///     Validates Sinch event request.
-        /// </summary>
-        /// <param name="headers">The Sinch event request headers.</param>
-        /// <param name="body">The Sinch event raw body, as received from the HTTP request.</param>
-        /// <param name="secret">The event destination secret used to generate the HMAC signature.</param>
-        /// <returns>True, if produced signature match with that of a header.</returns>
-        bool ValidateAuthenticationHeader(IReadOnlyDictionary<string, IEnumerable<string>> headers, string body,
-            string secret);
-
-        /// <summary>
-        ///     Parses a Sinch event payload from a raw JSON string.
-        /// </summary>
-        /// <param name="json">The raw Sinch event payload.</param>
-        /// <returns>The parsed Sinch event.</returns>
-        IConversationSinchEvent ParseEvent(string json);
-
-        /// <summary>
-        ///     Parses a Sinch event payload from a JSON stream.
-        /// </summary>
-        /// <param name="json">The Sinch event payload stream.</param>
-        /// <param name="cancellationToken">The cancellation token.</param>
-        /// <returns>The parsed Sinch event.</returns>
-        Task<IConversationSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
     }
 
     /// <inheritdoc />
@@ -203,46 +166,6 @@ namespace Sinch.Conversation.EventDestinations
             _logger?.LogDebug("Deleting a event destination with {id}...", eventDestinationId);
             return _http.Value.Send<object>(uri, HttpMethod.Delete,
                 cancellationToken);
-        }
-
-        public bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body,
-            string secret)
-        {
-            return HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, body);
-        }
-
-        public bool ValidateAuthenticationHeader(IReadOnlyDictionary<string, IEnumerable<string>> headers, string body,
-            string secret)
-        {
-            return HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, body);
-        }
-
-        public IConversationSinchEvent ParseEvent(string json)
-        {
-            var jsonResult = JsonSerializer.Deserialize<IConversationSinchEvent>(json, _http.Value.JsonSerializerOptions);
-            if (jsonResult == null)
-            {
-                _logger?.LogError("Failed to deserialize conversation Sinch event. No matching event type found for payload: {json}", json);
-                throw new InvalidOperationException("Deserialization of conversation Sinch event failed");
-            }
-
-            return jsonResult;
-        }
-
-        public async Task<IConversationSinchEvent> ParseEventAsync(Stream jsonStream,
-            CancellationToken cancellationToken = default)
-        {
-            var jsonResult =
-                await JsonSerializer.DeserializeAsync<IConversationSinchEvent>(jsonStream,
-                    SinchConversationClient.JsonSerializerOptionsInner,
-                    cancellationToken);
-            if (jsonResult == null)
-            {
-                _logger?.LogError("Failed to deserialize conversation Sinch event. No matching event type found.");
-                throw new InvalidOperationException("Deserialization of conversation Sinch event failed");
-            }
-
-            return jsonResult;
         }
     }
 }

--- a/src/Sinch/Conversation/SinchConversationClient.cs
+++ b/src/Sinch/Conversation/SinchConversationClient.cs
@@ -8,6 +8,7 @@ using Sinch.Conversation.Conversations;
 using Sinch.Conversation.EventDestinations;
 using Sinch.Conversation.Events;
 using Sinch.Conversation.Messages;
+using Sinch.Conversation.SinchEvents;
 using Sinch.Conversation.Transcoding;
 using Sinch.Conversation.TemplatesV2;
 using Sinch.Core;
@@ -37,6 +38,9 @@ namespace Sinch.Conversation
 
         /// <inheritdoc cref="ISinchConversationEventDestinations" />
         ISinchConversationEventDestinations EventDestinations { get; }
+
+        /// <inheritdoc cref="IConversationSinchEvents" />
+        IConversationSinchEvents SinchEvents { get; }
 
         /// <inheritdoc cref="ISinchConversationEvents" />
         ISinchConversationEvents Events { get; }
@@ -80,6 +84,8 @@ namespace Sinch.Conversation
                 loggerFactory?.Create<ISinchConversationConversations>(), http);
             EventDestinations = new EventDestinations.EventDestinations(projectId, conversationBaseAddress,
                 loggerFactory?.Create<ISinchConversationEventDestinations>(), http);
+            SinchEvents = new ConversationSinchEvents(JsonSerializerOptionsInner,
+                loggerFactory?.Create<IConversationSinchEvents>());
             Events = new Events.Events(projectId, conversationBaseAddress,
                 loggerFactory?.Create<ISinchConversationEvents>(), http);
             Transcoding = new Transcoding.Transcoding(projectId, conversationBaseAddress,
@@ -104,6 +110,9 @@ namespace Sinch.Conversation
 
         /// <inheritdoc />
         public ISinchConversationEventDestinations EventDestinations { get; }
+
+        /// <inheritdoc />
+        public IConversationSinchEvents SinchEvents { get; }
 
         /// <inheritdoc />
         public ISinchConversationEvents Events { get; }

--- a/src/Sinch/Conversation/SinchEvents/ConversationSinchEvents.cs
+++ b/src/Sinch/Conversation/SinchEvents/ConversationSinchEvents.cs
@@ -18,12 +18,6 @@ namespace Sinch.Conversation.SinchEvents
         public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
 
         /// <inheritdoc />
-        public bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body, string secret)
-        {
-            return HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, body);
-        }
-
-        /// <inheritdoc />
         public bool ValidateAuthenticationHeader(IReadOnlyDictionary<string, IEnumerable<string>> headers, string body,
             string secret)
         {

--- a/src/Sinch/Conversation/SinchEvents/ConversationSinchEvents.cs
+++ b/src/Sinch/Conversation/SinchEvents/ConversationSinchEvents.cs
@@ -16,7 +16,7 @@ namespace Sinch.Conversation.SinchEvents
     {
         /// <inheritdoc />
         public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
-        
+
         /// <inheritdoc />
         public bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body, string secret)
         {

--- a/src/Sinch/Conversation/SinchEvents/ConversationSinchEvents.cs
+++ b/src/Sinch/Conversation/SinchEvents/ConversationSinchEvents.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Sinch.Logger;
+
+namespace Sinch.Conversation.SinchEvents
+{
+    /// <inheritdoc />
+    internal sealed class ConversationSinchEvents(
+        JsonSerializerOptions jsonSerializerOptions,
+        ILoggerAdapter<IConversationSinchEvents>? logger = null)
+        : IConversationSinchEvents
+    {
+        /// <inheritdoc />
+        public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
+        
+        /// <inheritdoc />
+        public bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body, string secret)
+        {
+            return HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, body);
+        }
+
+        /// <inheritdoc />
+        public bool ValidateAuthenticationHeader(IReadOnlyDictionary<string, IEnumerable<string>> headers, string body,
+            string secret)
+        {
+            return HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, body);
+        }
+
+        /// <inheritdoc />
+        public IConversationSinchEvent ParseEvent(string json)
+        {
+            var result = JsonSerializer.Deserialize<IConversationSinchEvent>(json, JsonSerializerOptions);
+            if (result == null)
+            {
+                logger?.LogError(
+                    "Failed to deserialize Conversation Sinch event. No matching event type found for payload: {json}",
+                    json);
+                throw new InvalidOperationException("Deserialization of Conversation Sinch event failed");
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async Task<IConversationSinchEvent> ParseEventAsync(Stream jsonStream,
+            CancellationToken cancellationToken = default)
+        {
+            var result =
+                await JsonSerializer.DeserializeAsync<IConversationSinchEvent>(jsonStream, JsonSerializerOptions,
+                    cancellationToken);
+            if (result == null)
+            {
+                logger?.LogError("Failed to deserialize Conversation Sinch event. No matching event type found.");
+                throw new InvalidOperationException("Deserialization of Conversation Sinch event failed");
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Sinch/Conversation/SinchEvents/HmacAuthenticationValidation.cs
+++ b/src/Sinch/Conversation/SinchEvents/HmacAuthenticationValidation.cs
@@ -20,28 +20,6 @@ internal sealed class HmacAuthenticationValidation
     ///     Validates the HMAC authentication header from a Conversation event destination request.
     /// </summary>
     /// <param name="secret">The event destination secret.</param>
-    /// <param name="headers">HTTP headers from the request as single-value entries.</param>
-    /// <param name="jsonPayload">The raw JSON payload body.</param>
-    /// <returns>True if the signature is valid, false otherwise.</returns>
-    /// <exception cref="NotSupportedException">Thrown when the HMAC algorithm is not supported.</exception>
-    public static bool ValidateAuthenticationHeader(
-        string secret,
-        IDictionary<string, string> headers,
-        string jsonPayload)
-    {
-        var multiValueHeaders = new Dictionary<string, IEnumerable<string>>(headers.Count, StringComparer.OrdinalIgnoreCase);
-        foreach (var header in headers)
-        {
-            multiValueHeaders[header.Key] = [header.Value];
-        }
-
-        return ValidateAuthenticationHeader(secret, multiValueHeaders, jsonPayload);
-    }
-
-    /// <summary>
-    ///     Validates the HMAC authentication header from a Conversation event destination request.
-    /// </summary>
-    /// <param name="secret">The event destination secret.</param>
     /// <param name="headers">HTTP headers from the request (case-insensitive lookup will be performed).</param>
     /// <param name="jsonPayload">The raw JSON payload body.</param>
     /// <returns>True if the signature is valid, false otherwise.</returns>

--- a/src/Sinch/Conversation/SinchEvents/HmacAuthenticationValidation.cs
+++ b/src/Sinch/Conversation/SinchEvents/HmacAuthenticationValidation.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 
-namespace Sinch.Conversation.EventDestinations;
+namespace Sinch.Conversation.SinchEvents;
 
 /// <summary>
 ///     Validates HMAC authentication headers for Conversation event destination requests.

--- a/src/Sinch/Conversation/SinchEvents/IConversationSinchEvents.cs
+++ b/src/Sinch/Conversation/SinchEvents/IConversationSinchEvents.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sinch.Conversation.SinchEvents
+{
+    /// <summary>
+    ///     Conversation Sinch Events service. Provides helpers for parsing and validating
+    ///     incoming Sinch event payloads delivered by the Conversation API.
+    /// </summary>
+    public interface IConversationSinchEvents
+    {
+        /// <summary>
+        ///     The <see cref="JsonSerializerOptions" /> used to deserialize Conversation events.
+        /// </summary>
+        JsonSerializerOptions JsonSerializerOptions { get; }
+        
+        /// <summary>
+        ///     Validates the Sinch event HMAC authentication header.
+        /// </summary>
+        /// <param name="headers">The HTTP headers from the incoming Sinch event request as single-value entries.</param>
+        /// <param name="body">The raw request body.</param>
+        /// <param name="secret">The event destination secret used to generate the HMAC signature.</param>
+        /// <returns>True if the produced signature matches the header value.</returns>
+        bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body, string secret);
+
+        /// <summary>
+        ///     Validates the Sinch event HMAC authentication header.
+        /// </summary>
+        /// <param name="headers">The HTTP headers from the incoming Sinch event request.</param>
+        /// <param name="body">The raw request body.</param>
+        /// <param name="secret">The event destination secret used to generate the HMAC signature.</param>
+        /// <returns>True if the produced signature matches the header value.</returns>
+        bool ValidateAuthenticationHeader(IReadOnlyDictionary<string, IEnumerable<string>> headers, string body,
+            string secret);
+
+        /// <summary>
+        ///     Parses a Conversation Sinch event from a JSON string.
+        /// </summary>
+        /// <param name="json">The raw JSON payload from the Sinch event request body.</param>
+        /// <returns>
+        ///     Parsed Conversation Sinch event. Use pattern matching to handle specific event types:
+        ///     <list type="bullet">
+        ///         <item><description><see cref="MessageInboundEvent"/> — An inbound message from an end user.</description></item>
+        ///         <item><description><see cref="MessageDeliveryReceiptEvent"/> — A message delivery receipt.</description></item>
+        ///         <item><description><see cref="MessageSubmitEvent"/> — A message submission notification.</description></item>
+        ///         <item><description><see cref="DeliveryEvent"/> — An event delivery receipt.</description></item>
+        ///         <item><description><see cref="InboundEvent"/> — An inbound event from an end user.</description></item>
+        ///         <item><description><see cref="CapabilityEvent"/> — A channel capability lookup result.</description></item>
+        ///         <item><description><see cref="ContactCreateEvent"/> — A contact was created.</description></item>
+        ///         <item><description><see cref="ContactDeleteEvent"/> — A contact was deleted.</description></item>
+        ///         <item><description><see cref="ContactMergeEvent"/> — Two contacts were merged.</description></item>
+        ///         <item><description><see cref="ContactUpdateEvent"/> — A contact was updated.</description></item>
+        ///         <item><description><see cref="ConversationStartEvent"/> — A conversation was started.</description></item>
+        ///         <item><description><see cref="ConversationStopEvent"/> — A conversation was stopped.</description></item>
+        ///         <item><description><see cref="ConversationDeleteEvent"/> — A conversation was deleted.</description></item>
+        ///         <item><description><see cref="ChannelEvent"/> — A channel-specific event.</description></item>
+        ///         <item><description><see cref="OptInEvent"/> — An opt-in notification.</description></item>
+        ///         <item><description><see cref="OptOutEvent"/> — An opt-out notification.</description></item>
+        ///         <item><description><see cref="SmartConversationsEvent"/> — A Smart Conversations analysis result.</description></item>
+        ///     </list>
+        /// </returns>
+        /// <exception cref="System.Text.Json.JsonException">Thrown when JSON is invalid or cannot be deserialized.</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
+        IConversationSinchEvent ParseEvent(string json);
+
+        /// <summary>
+        ///     Parses a Conversation Sinch event from a stream.
+        /// </summary>
+        /// <param name="json">A stream containing the JSON payload from the Sinch event request body.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Parsed Conversation Sinch event.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
+        Task<IConversationSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Sinch/Conversation/SinchEvents/IConversationSinchEvents.cs
+++ b/src/Sinch/Conversation/SinchEvents/IConversationSinchEvents.cs
@@ -20,15 +20,6 @@ namespace Sinch.Conversation.SinchEvents
         /// <summary>
         ///     Validates the Sinch event HMAC authentication header.
         /// </summary>
-        /// <param name="headers">The HTTP headers from the incoming Sinch event request as single-value entries.</param>
-        /// <param name="body">The raw request body.</param>
-        /// <param name="secret">The event destination secret used to generate the HMAC signature.</param>
-        /// <returns>True if the produced signature matches the header value.</returns>
-        bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body, string secret);
-
-        /// <summary>
-        ///     Validates the Sinch event HMAC authentication header.
-        /// </summary>
         /// <param name="headers">The HTTP headers from the incoming Sinch event request.</param>
         /// <param name="body">The raw request body.</param>
         /// <param name="secret">The event destination secret used to generate the HMAC signature.</param>

--- a/src/Sinch/Conversation/SinchEvents/IConversationSinchEvents.cs
+++ b/src/Sinch/Conversation/SinchEvents/IConversationSinchEvents.cs
@@ -16,7 +16,7 @@ namespace Sinch.Conversation.SinchEvents
         ///     The <see cref="JsonSerializerOptions" /> used to deserialize Conversation events.
         /// </summary>
         JsonSerializerOptions JsonSerializerOptions { get; }
-        
+
         /// <summary>
         ///     Validates the Sinch event HMAC authentication header.
         /// </summary>

--- a/src/Sinch/Core/AuthorizationHeaderValidation.cs
+++ b/src/Sinch/Core/AuthorizationHeaderValidation.cs
@@ -74,7 +74,7 @@ namespace Sinch.Core
         }
 
         public static bool Validate<TLogger>(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers, string body, ApplicationSignedAuth applicationSignedAuth,
+            IDictionary<string, IEnumerable<string>> headers, string body, ApplicationSignedAuth applicationSignedAuth,
             ILoggerAdapter<TLogger>? logger = null)
         {
             var reHeaders = headers.ToDictionary(x => x.Key, y => new StringValues(y.Value.ToArray()));

--- a/src/Sinch/Fax/FaxClient.cs
+++ b/src/Sinch/Fax/FaxClient.cs
@@ -23,8 +23,8 @@ namespace Sinch.Fax
         /// <inheritdoc cref="ISinchFaxServices" />
         public ISinchFaxServices Services { get; }
 
-        /// <inheritdoc cref="ISinchFaxSinchEvents" />
-        public ISinchFaxSinchEvents SinchEvents { get; }
+        /// <inheritdoc cref="IFaxSinchEvents" />
+        public IFaxSinchEvents SinchEvents { get; }
     }
 
     internal sealed class FaxClient : ISinchFax
@@ -34,7 +34,7 @@ namespace Sinch.Fax
             Faxes = new FaxesClient(projectId, baseAddress, loggerFactory?.Create<ISinchFaxFaxes>(), http);
             Services = new ServicesClient(projectId, baseAddress, loggerFactory?.Create<ISinchFaxServices>(), http);
             Emails = new EmailsClient(projectId, baseAddress, loggerFactory?.Create<ISinchFaxEmails>(), http);
-            SinchEvents = new FaxSinchEvents(http.JsonSerializerOptions, loggerFactory?.Create<ISinchFaxSinchEvents>());
+            SinchEvents = new FaxSinchEvents(http.JsonSerializerOptions, loggerFactory?.Create<IFaxSinchEvents>());
         }
 
         /// <inheritdoc />
@@ -47,6 +47,6 @@ namespace Sinch.Fax
         public ISinchFaxServices Services { get; }
 
         /// <inheritdoc />
-        public ISinchFaxSinchEvents SinchEvents { get; }
+        public IFaxSinchEvents SinchEvents { get; }
     }
 }

--- a/src/Sinch/Fax/SinchEvents/CompletedFaxEvent.cs
+++ b/src/Sinch/Fax/SinchEvents/CompletedFaxEvent.cs
@@ -4,7 +4,7 @@ using Sinch.Fax.Faxes;
 
 namespace Sinch.Fax.SinchEvents
 {
-    public sealed class CompletedFaxEvent : FaxSinchEventBase, IFaxSinchEvent
+    public sealed class CompletedFaxEvent : FaxSinchEventBase
     {
         public override FaxEventType Event { get; } = FaxEventType.CompletedFax;
 

--- a/src/Sinch/Fax/SinchEvents/FaxSinchEventBase.cs
+++ b/src/Sinch/Fax/SinchEvents/FaxSinchEventBase.cs
@@ -4,7 +4,7 @@ using System.Text.Json.Serialization;
 
 namespace Sinch.Fax.SinchEvents
 {
-    public abstract class FaxSinchEventBase
+    public abstract class FaxSinchEventBase : IFaxSinchEvent
     {
         /// <summary>
         ///     The type of the Fax Sinch event.

--- a/src/Sinch/Fax/SinchEvents/FaxSinchEvents.cs
+++ b/src/Sinch/Fax/SinchEvents/FaxSinchEvents.cs
@@ -28,7 +28,7 @@ namespace Sinch.Fax.SinchEvents
         }
 
         /// <inheritdoc />
-        public bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body)
+        public bool ValidateAuthenticationHeader(IDictionary<string, IEnumerable<string>> headers, string body)
         {
             // No header validation is defined for the Fax API.
             return true;

--- a/src/Sinch/Fax/SinchEvents/FaxSinchEvents.cs
+++ b/src/Sinch/Fax/SinchEvents/FaxSinchEvents.cs
@@ -8,8 +8,8 @@ namespace Sinch.Fax.SinchEvents
     /// <inheritdoc />
     internal sealed class FaxSinchEvents(
         JsonSerializerOptions jsonSerializerOptions,
-        ILoggerAdapter<ISinchFaxSinchEvents>? logger = null)
-        : ISinchFaxSinchEvents
+        ILoggerAdapter<IFaxSinchEvents>? logger = null)
+        : IFaxSinchEvents
     {
         public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
 

--- a/src/Sinch/Fax/SinchEvents/FaxSinchEvents.cs
+++ b/src/Sinch/Fax/SinchEvents/FaxSinchEvents.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Sinch.Logger;
 
 namespace Sinch.Fax.SinchEvents
@@ -21,6 +24,19 @@ namespace Sinch.Fax.SinchEvents
             {
                 logger?.LogError(
                     "Failed to deserialize Fax Sinch event. No matching event type found for payload: {json}", json);
+                throw new InvalidOperationException("Deserialization of Fax Sinch event failed");
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async Task<IFaxSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default)
+        {
+            var result = await JsonSerializer.DeserializeAsync<IFaxSinchEvent>(json, JsonSerializerOptions, cancellationToken);
+            if (result == null)
+            {
+                logger?.LogError("Failed to deserialize Fax Sinch event. No matching event type found.");
                 throw new InvalidOperationException("Deserialization of Fax Sinch event failed");
             }
 

--- a/src/Sinch/Fax/SinchEvents/IFaxSinchEvent.cs
+++ b/src/Sinch/Fax/SinchEvents/IFaxSinchEvent.cs
@@ -10,6 +10,6 @@ namespace Sinch.Fax.SinchEvents
         ///     The type of the Fax Sinch event.
         /// </summary>
         [JsonPropertyName("event")]
-        public FaxEventType Event { get; }
+        FaxEventType Event { get; }
     }
 }

--- a/src/Sinch/Fax/SinchEvents/IFaxSinchEvents.cs
+++ b/src/Sinch/Fax/SinchEvents/IFaxSinchEvents.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Sinch.Fax.SinchEvents
 {
@@ -9,7 +12,7 @@ namespace Sinch.Fax.SinchEvents
     /// </summary>
     public interface IFaxSinchEvents
     {
-        internal JsonSerializerOptions JsonSerializerOptions { get; }
+        JsonSerializerOptions JsonSerializerOptions { get; }
 
         /// <summary>
         ///     Parse a Fax Sinch event from a JSON payload.
@@ -25,6 +28,15 @@ namespace Sinch.Fax.SinchEvents
         /// <exception cref="System.Text.Json.JsonException">Thrown when JSON is invalid or cannot be deserialized.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when event type is unknown or deserialization fails.</exception>
         IFaxSinchEvent ParseEvent(string json);
+
+        /// <summary>
+        ///     Parse a Fax Sinch event from a stream.
+        /// </summary>
+        /// <param name="json">A stream containing the JSON payload from the Sinch event request body.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Parsed Fax Sinch event.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when event type is unknown or deserialization fails.</exception>
+        Task<IFaxSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Validates the Sinch event authentication header.

--- a/src/Sinch/Fax/SinchEvents/IFaxSinchEvents.cs
+++ b/src/Sinch/Fax/SinchEvents/IFaxSinchEvents.cs
@@ -35,6 +35,6 @@ namespace Sinch.Fax.SinchEvents
         ///     Always returns <c>true</c>. The Fax API does not define an authentication header
         ///     validation scheme, so no signature verification is performed.
         /// </returns>
-        bool ValidateAuthenticationHeader(IDictionary<string, string> headers, string body);
+        bool ValidateAuthenticationHeader(IDictionary<string, IEnumerable<string>> headers, string body);
     }
 }

--- a/src/Sinch/Fax/SinchEvents/IFaxSinchEvents.cs
+++ b/src/Sinch/Fax/SinchEvents/IFaxSinchEvents.cs
@@ -7,7 +7,7 @@ namespace Sinch.Fax.SinchEvents
     ///     Fax Sinch Events service. Provides helpers for parsing and validating
     ///     incoming Sinch event payloads delivered by the Fax API.
     /// </summary>
-    public interface ISinchFaxSinchEvents
+    public interface IFaxSinchEvents
     {
         internal JsonSerializerOptions JsonSerializerOptions { get; }
 

--- a/src/Sinch/Fax/SinchEvents/IncomingFaxEvent.cs
+++ b/src/Sinch/Fax/SinchEvents/IncomingFaxEvent.cs
@@ -3,7 +3,7 @@ using Sinch.Fax.Faxes;
 
 namespace Sinch.Fax.SinchEvents
 {
-    public sealed class IncomingFaxEvent : FaxSinchEventBase, IFaxSinchEvent
+    public sealed class IncomingFaxEvent : FaxSinchEventBase
     {
         public override FaxEventType Event { get; } = FaxEventType.IncomingFax;
 

--- a/src/Sinch/Numbers/Numbers.cs
+++ b/src/Sinch/Numbers/Numbers.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +13,7 @@ using Sinch.Numbers.Available.List;
 using Sinch.Numbers.Available.Rent;
 using Sinch.Numbers.Available.RentAny;
 using Sinch.Numbers.EventDestinations;
+using Sinch.Numbers.SinchEvents;
 
 namespace Sinch.Numbers
 {
@@ -30,6 +30,9 @@ namespace Sinch.Numbers
 
         /// <inheritdoc cref="ISinchNumbersEventDestinations"/>
         public ISinchNumbersEventDestinations EventDestinations { get; }
+
+        /// <inheritdoc cref="INumbersSinchEvents"/>
+        public INumbersSinchEvents SinchEvents { get; }
 
         /// <inheritdoc cref="ISinchNumbersAvailable.RentAny" />
         Task<ActiveNumber> RentAny(RentAnyNumberRequest request,
@@ -77,24 +80,6 @@ namespace Sinch.Numbers
         ///     For internal use, JsonSerializerOption to be utilized for serialization and deserialization of all Numbers models
         /// </summary>
         internal JsonSerializerOptions JsonSerializerOptions { get; }
-
-        /// <summary>
-        ///     Validates json of a Sinch event with your HMAC secret 
-        /// </summary>
-        /// <param name="hmacSecret">Your HMAC secret</param>
-        /// <param name="json">The JSON payload as a raw string to be validated.</param>
-        /// <param name="signatureHeaderValue">A value of X-Sinch-Signature header</param>
-        /// <returns>True if a validation is successful</returns>
-        bool ValidateAuthenticationHeader(string hmacSecret, string json, string signatureHeaderValue);
-
-        /// <summary>
-        ///     Validates json of a Sinch event with your HMAC secret 
-        /// </summary>
-        /// <param name="hmacSecret">Your HMAC secret</param>
-        /// <param name="json">The JSON payload as a raw string to be validated.</param>
-        /// <param name="headers">Headers of a Sinch event message, where method will look up for X-Sinch-Signature header</param>
-        /// <returns>True if a validation is successful</returns>
-        bool ValidateAuthenticationHeader(string hmacSecret, string json, HttpHeaders headers);
     }
 
     public sealed class Numbers : ISinchNumbers
@@ -112,12 +97,17 @@ namespace Sinch.Numbers
                 loggerFactory?.Create<AvailableNumbers>(), http);
             EventDestinations = new SinchNumbersEventDestinations(projectId, baseAddress,
                 loggerFactory?.Create<ISinchNumbersEventDestinations>(), http);
+            SinchEvents = new NumbersSinchEvents(http.JsonSerializerOptions,
+                loggerFactory?.Create<INumbersSinchEvents>());
             JsonSerializerOptions = http.JsonSerializerOptions;
         }
 
         public ISinchNumbersRegions Regions { get; }
 
         public ISinchNumbersEventDestinations EventDestinations { get; }
+
+        /// <inheritdoc />
+        public INumbersSinchEvents SinchEvents { get; }
 
         /// <inheritdoc />
         public Task<ActiveNumber> RentAny(RentAnyNumberRequest request, CancellationToken cancellationToken = default)
@@ -192,15 +182,5 @@ namespace Sinch.Numbers
         }
 
         public JsonSerializerOptions JsonSerializerOptions { get; }
-
-        public bool ValidateAuthenticationHeader(string hmacSecret, string json, string signatureHeaderValue)
-        {
-            return HeaderValidation.ValidateAuthHeader(hmacSecret, json, signatureHeaderValue);
-        }
-
-        public bool ValidateAuthenticationHeader(string hmacSecret, string json, HttpHeaders headers)
-        {
-            return HeaderValidation.ValidateAuthHeader(hmacSecret, json, headers);
-        }
     }
 }

--- a/src/Sinch/Numbers/SinchEvents/INumberSinchEvent.cs
+++ b/src/Sinch/Numbers/SinchEvents/INumberSinchEvent.cs
@@ -1,61 +1,53 @@
 using System;
-using System.Text.Json.Serialization;
 
 namespace Sinch.Numbers.SinchEvents
 {
     /// <summary>
-    ///     A notification of an event sent to your configured Sinch event URL.
+    ///     Represents a Sinch Numbers event notification.
     /// </summary>
-    public sealed class NumberSinchEvent : INumberSinchEvent
+    public interface INumberSinchEvent
     {
         /// <summary>
         ///     The ID of the event.
         /// </summary>
-        [JsonPropertyName("eventId")]
-        public string? EventId { get; set; }
+        string? EventId { get; }
 
         /// <summary>
         ///     The date and time when the Sinch event was created and added to the Sinch events queue.
         /// </summary>
-        [JsonPropertyName("timestamp")]
-        public DateTime? Timestamp { get; set; }
+        DateTime? Timestamp { get; }
 
         /// <summary>
         ///     The ID of the project to which the event belongs.
         /// </summary>
-        [JsonPropertyName("projectId")]
-        public string? ProjectId { get; set; }
+        string? ProjectId { get; }
 
         /// <summary>
         ///     The unique identifier of the resource, depending on the resource type.
         ///     For example, a phone number, a hosting order ID, or a brand ID.
         /// </summary>
-        [JsonPropertyName("resourceId")]
-        public string? ResourceId { get; set; }
+        string? ResourceId { get; }
 
         /// <summary>
-        ///     The type of the resource. 
+        ///     The type of the resource.
         /// </summary>
-        [JsonPropertyName("resourceType")]
-        public ResourceType? ResourceType { get; set; }
+        ResourceType? ResourceType { get; }
 
         /// <summary>
         ///     The type of the event.
         /// </summary>
-        [JsonPropertyName("eventType")]
-        public EventType? EventType { get; set; }
+        EventType? EventType { get; }
 
         /// <summary>
-        ///     The status of the event
+        ///     The status of the event.
         /// </summary>
-        [JsonPropertyName("status")]
-        public EventStatus? Status { get; set; }
+        EventStatus? Status { get; }
 
         /// <summary>
         ///     If the status is FAILED, a failure code will be provided.
         ///     For numbers provisioning to SMS platform, there won't be any extra failureCode, as the result is binary.
         /// </summary>
-        [JsonPropertyName("failureCode")]
-        public FailureCode? FailureCode { get; set; }
+        FailureCode? FailureCode { get; }
     }
 }
+

--- a/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
@@ -1,0 +1,42 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Sinch.Numbers.SinchEvents
+{
+    /// <summary>
+    ///     Numbers Sinch Events service. Provides helpers for parsing and validating
+    ///     incoming Sinch event payloads delivered by the Numbers API.
+    /// </summary>
+    public interface INumbersSinchEvents
+    {
+        /// <summary>
+        ///     For internal use: the <see cref="JsonSerializerOptions" /> used to deserialize Numbers events.
+        /// </summary>
+        JsonSerializerOptions JsonSerializerOptions { get; }
+        
+        /// <summary>
+        ///     Parses a Sinch Numbers event from a raw JSON string.
+        /// </summary>
+        /// <param name="json">The raw Sinch event payload.</param>
+        /// <returns>The parsed <see cref="NumberSinchEvent" />.</returns>
+        NumberSinchEvent ParseEvent(string json);
+
+        /// <summary>
+        ///     Validates a Sinch Numbers event using your HMAC secret and the raw signature header value.
+        /// </summary>
+        /// <param name="hmacSecret">Your HMAC secret.</param>
+        /// <param name="json">The JSON payload as a raw string.</param>
+        /// <param name="signatureHeaderValue">The value of the <c>X-Sinch-Signature</c> header.</param>
+        /// <returns>True if the validation is successful.</returns>
+        bool ValidateAuthenticationHeader(string hmacSecret, string json, string signatureHeaderValue);
+
+        /// <summary>
+        ///     Validates a Sinch Numbers event using your HMAC secret and the full request headers collection.
+        /// </summary>
+        /// <param name="hmacSecret">Your HMAC secret.</param>
+        /// <param name="json">The JSON payload as a raw string.</param>
+        /// <param name="headers">The HTTP headers of the incoming Sinch event request.</param>
+        /// <returns>True if the validation is successful.</returns>
+        bool ValidateAuthenticationHeader(string hmacSecret, string json, HttpHeaders headers);
+    }
+}

--- a/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
@@ -18,8 +18,8 @@ namespace Sinch.Numbers.SinchEvents
         ///     Parses a Sinch Numbers event from a raw JSON string.
         /// </summary>
         /// <param name="json">The raw Sinch event payload.</param>
-        /// <returns>The parsed <see cref="NumberSinchEvent" />.</returns>
-        NumberSinchEvent ParseEvent(string json);
+        /// <returns>The parsed <see cref="INumberSinchEvent" />.</returns>
+        INumberSinchEvent ParseEvent(string json);
 
         /// <summary>
         ///     Validates a Sinch Numbers event using your HMAC secret and the raw signature header value.

--- a/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
@@ -1,5 +1,8 @@
+using System.IO;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Sinch.Numbers.SinchEvents
 {
@@ -20,6 +23,15 @@ namespace Sinch.Numbers.SinchEvents
         /// <param name="json">The raw Sinch event payload.</param>
         /// <returns>The parsed <see cref="INumberSinchEvent" />.</returns>
         INumberSinchEvent ParseEvent(string json);
+
+        /// <summary>
+        ///     Parses a Sinch Numbers event from a stream.
+        /// </summary>
+        /// <param name="json">A stream containing the JSON payload from the Sinch event request body.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The parsed <see cref="INumberSinchEvent" />.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when deserialization fails.</exception>
+        Task<INumberSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Validates a Sinch Numbers event using your HMAC secret and the raw signature header value.

--- a/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/INumbersSinchEvents.cs
@@ -13,7 +13,7 @@ namespace Sinch.Numbers.SinchEvents
         ///     For internal use: the <see cref="JsonSerializerOptions" /> used to deserialize Numbers events.
         /// </summary>
         JsonSerializerOptions JsonSerializerOptions { get; }
-        
+
         /// <summary>
         ///     Parses a Sinch Numbers event from a raw JSON string.
         /// </summary>

--- a/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
@@ -9,7 +9,7 @@ namespace Sinch.Numbers.SinchEvents
         ILoggerAdapter<INumbersSinchEvents>? logger = null) : INumbersSinchEvents
     {
         public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
-        
+
         public NumberSinchEvent ParseEvent(string json)
         {
             var result = JsonSerializer.Deserialize<NumberSinchEvent>(json, JsonSerializerOptions);

--- a/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
@@ -1,5 +1,8 @@
+using System.IO;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Sinch.Core;
 using Sinch.Logger;
 
@@ -13,6 +16,18 @@ namespace Sinch.Numbers.SinchEvents
         public INumberSinchEvent ParseEvent(string json)
         {
             var result = JsonSerializer.Deserialize<NumberSinchEvent>(json, JsonSerializerOptions);
+            if (result == null)
+            {
+                logger?.LogError("Failed to deserialize Numbers Sinch event.");
+                throw new System.InvalidOperationException("Deserialization of Numbers Sinch event failed");
+            }
+
+            return result;
+        }
+
+        public async Task<INumberSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default)
+        {
+            var result = await JsonSerializer.DeserializeAsync<NumberSinchEvent>(json, JsonSerializerOptions, cancellationToken);
             if (result == null)
             {
                 logger?.LogError("Failed to deserialize Numbers Sinch event.");

--- a/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
@@ -10,7 +10,7 @@ namespace Sinch.Numbers.SinchEvents
     {
         public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
 
-        public NumberSinchEvent ParseEvent(string json)
+        public INumberSinchEvent ParseEvent(string json)
         {
             var result = JsonSerializer.Deserialize<NumberSinchEvent>(json, JsonSerializerOptions);
             if (result == null)

--- a/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
@@ -1,0 +1,35 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Sinch.Core;
+using Sinch.Logger;
+
+namespace Sinch.Numbers.SinchEvents
+{
+    internal sealed class NumbersSinchEvents(JsonSerializerOptions jsonSerializerOptions,
+        ILoggerAdapter<INumbersSinchEvents>? logger) : INumbersSinchEvents
+    {
+        public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
+        
+        public NumberSinchEvent ParseEvent(string json)
+        {
+            var result = JsonSerializer.Deserialize<NumberSinchEvent>(json, JsonSerializerOptions);
+            if (result == null)
+            {
+                logger?.LogError("Failed to deserialize Numbers Sinch event.");
+                throw new System.InvalidOperationException("Deserialization of Numbers Sinch event failed");
+            }
+
+            return result;
+        }
+
+        public bool ValidateAuthenticationHeader(string hmacSecret, string json, string signatureHeaderValue)
+        {
+            return HeaderValidation.ValidateAuthHeader(hmacSecret, json, signatureHeaderValue);
+        }
+
+        public bool ValidateAuthenticationHeader(string hmacSecret, string json, HttpHeaders headers)
+        {
+            return HeaderValidation.ValidateAuthHeader(hmacSecret, json, headers);
+        }
+    }
+}

--- a/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
+++ b/src/Sinch/Numbers/SinchEvents/NumbersSinchEvents.cs
@@ -6,7 +6,7 @@ using Sinch.Logger;
 namespace Sinch.Numbers.SinchEvents
 {
     internal sealed class NumbersSinchEvents(JsonSerializerOptions jsonSerializerOptions,
-        ILoggerAdapter<INumbersSinchEvents>? logger) : INumbersSinchEvents
+        ILoggerAdapter<INumbersSinchEvents>? logger = null) : INumbersSinchEvents
     {
         public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
         

--- a/src/Sinch/SMS/SinchEvents/HmacAuthenticationValidation.cs
+++ b/src/Sinch/SMS/SinchEvents/HmacAuthenticationValidation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Cryptography;
 
 namespace Sinch.SMS.SinchEvents;
@@ -24,13 +25,24 @@ internal sealed class HmacAuthenticationValidation
     /// <exception cref="System.NotSupportedException">Thrown when the HMAC algorithm is not supported.</exception>
     public static bool ValidateAuthenticationHeader(
         string secret,
-        IDictionary<string, string> headers,
+        IDictionary<string, IEnumerable<string>> headers,
         string jsonPayload)
     {
-        var caseInsensitiveHeaders = new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
+        var caseInsensitiveHeaders = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in headers)
+            caseInsensitiveHeaders[kvp.Key] = kvp.Value;
 
-        bool TryGetHeader(string name, out string value) =>
-            caseInsensitiveHeaders.TryGetValue(name, out value!) && !string.IsNullOrEmpty(value);
+        bool TryGetHeader(string name, out string value)
+        {
+            value = string.Empty;
+            if (!caseInsensitiveHeaders.TryGetValue(name, out var values))
+                return false;
+            var headerValue = values?.FirstOrDefault();
+            if (string.IsNullOrEmpty(headerValue))
+                return false;
+            value = headerValue;
+            return true;
+        }
 
         if (string.IsNullOrEmpty(secret) ||
             !TryGetHeader(TimestampHeader, out var timestampHeader) ||

--- a/src/Sinch/SMS/SinchEvents/HmacAuthenticationValidation.cs
+++ b/src/Sinch/SMS/SinchEvents/HmacAuthenticationValidation.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 
-namespace Sinch.SMS;
+namespace Sinch.SMS.SinchEvents;
 
 /// <summary>
 ///     Validates HMAC authentication headers for Sinch event requests.

--- a/src/Sinch/SMS/SinchEvents/ISmsSinchEvents.cs
+++ b/src/Sinch/SMS/SinchEvents/ISmsSinchEvents.cs
@@ -80,7 +80,7 @@ namespace Sinch.SMS.SinchEvents
         /// </remarks>
         bool ValidateAuthenticationHeader(
             string secret,
-            IDictionary<string, string> headers,
+            IDictionary<string, IEnumerable<string>> headers,
             string body);
     }
 }

--- a/src/Sinch/SMS/SinchEvents/ISmsSinchEvents.cs
+++ b/src/Sinch/SMS/SinchEvents/ISmsSinchEvents.cs
@@ -34,7 +34,7 @@ namespace Sinch.SMS.SinchEvents
     /// <seealso href="https://developers.sinch.com/docs/sms/api-reference/sms/tag/Webhooks/">SMS Webhooks Documentation</seealso>
     public interface ISmsSinchEvents
     {
-        internal JsonSerializerOptions JsonSerializerOptions { get; }
+        JsonSerializerOptions JsonSerializerOptions { get; }
 
         /// <summary>
         ///     Parse a Sinch event from JSON payload.

--- a/src/Sinch/SMS/SinchEvents/ISmsSinchEvents.cs
+++ b/src/Sinch/SMS/SinchEvents/ISmsSinchEvents.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Sinch.SMS.DeliveryReports;
 using Sinch.SMS.Inbounds;
 
@@ -53,6 +56,15 @@ namespace Sinch.SMS.SinchEvents
         /// <exception cref="System.Text.Json.JsonException">Thrown when JSON is invalid or cannot be deserialized.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when event type is unknown or deserialization fails.</exception>
         ISmsSinchEvent ParseEvent(string json);
+
+        /// <summary>
+        ///     Parse a Sinch event from a stream.
+        /// </summary>
+        /// <param name="json">A stream containing the JSON payload from the Sinch event request body.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Parsed SMS Sinch event.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when event type is unknown or deserialization fails.</exception>
+        Task<ISmsSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
 
         /// <summary>
         ///     Validate Sinch event authentication using HMAC signature.

--- a/src/Sinch/SMS/SinchEvents/SmsSinchEvents.cs
+++ b/src/Sinch/SMS/SinchEvents/SmsSinchEvents.cs
@@ -29,7 +29,7 @@ namespace Sinch.SMS.SinchEvents
         /// <inheritdoc />
         public bool ValidateAuthenticationHeader(
             string secret,
-            IDictionary<string, string> headers,
+            IDictionary<string, IEnumerable<string>> headers,
             string body)
         {
             return HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, body);

--- a/src/Sinch/SMS/SinchEvents/SmsSinchEvents.cs
+++ b/src/Sinch/SMS/SinchEvents/SmsSinchEvents.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 using Sinch.Logger;
 
 namespace Sinch.SMS.SinchEvents
@@ -20,6 +23,19 @@ namespace Sinch.SMS.SinchEvents
             if (result == null)
             {
                 logger?.LogError("Failed to deserialize SMS Sinch event. No matching event type found for payload: {json}", json);
+                throw new InvalidOperationException("Deserialization of SMS Sinch event failed");
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async Task<ISmsSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default)
+        {
+            var result = await JsonSerializer.DeserializeAsync<ISmsSinchEvent>(json, JsonSerializerOptions, cancellationToken);
+            if (result == null)
+            {
+                logger?.LogError("Failed to deserialize SMS Sinch event. No matching event type found.");
                 throw new InvalidOperationException("Deserialization of SMS Sinch event failed");
             }
 

--- a/src/Sinch/SMS/SmsClient.cs
+++ b/src/Sinch/SMS/SmsClient.cs
@@ -60,7 +60,7 @@ namespace Sinch.SMS
         ///     SMS Sinch events are configured in the Sinch Dashboard, not via API.
         ///     This service only handles parsing and validation of incoming Sinch event requests.
         /// </remarks>
-        ISmsSinchEvents SmsSinchEvents { get; }
+        ISmsSinchEvents SinchEvents { get; }
 
         internal bool IsUsingServicePlanId { get; }
     }
@@ -116,7 +116,7 @@ namespace Sinch.SMS
                 http);
             DeliveryReports = new DeliveryReports.DeliveryReports(projectIdOrServicePlanId, baseAddress,
                 loggerFactory?.Create<ISinchSmsDeliveryReports>(), http);
-            SmsSinchEvents = new SmsSinchEvents(
+            SinchEvents = new SmsSinchEvents(
                 http.JsonSerializerOptions,
                 loggerFactory?.Create<ISmsSinchEvents>());
         }
@@ -129,7 +129,7 @@ namespace Sinch.SMS
 
         public ISinchSmsDeliveryReports DeliveryReports { get; }
 
-        public ISmsSinchEvents SmsSinchEvents { get; }
+        public ISmsSinchEvents SinchEvents { get; }
 
         public bool IsUsingServicePlanId { get; }
     }

--- a/src/Sinch/SinchClient.cs
+++ b/src/Sinch/SinchClient.cs
@@ -275,7 +275,6 @@ namespace Sinch
         {
             var conversationConfig = _sinchClientConfiguration.ConversationConfiguration;
 
-            // TODO! Need to be refactored when the EventsDestination support will be addressed: https://sinchenterprise.atlassian.net/browse/DEVEXP-1311
             if (conversationConfig.Region == null)
                 throw new InvalidOperationException(
                     $"{nameof(SinchConversationConfiguration)}.{nameof(SinchConversationConfiguration.Region)} is required. " +
@@ -292,9 +291,6 @@ namespace Sinch
             return new SinchConversationClient(
                 _sinchClientConfiguration.SinchUnifiedCredentials
                     ?.ProjectId!,
-                // unified credentials, alongside projectId, will be validated as part of lazy call to http
-                // this is needed for working of Conversation.Webhooks.ParseEvent() to be accessible, without providing
-                // SinchUnifiedCredentials, the design regarding just a static method for this is still in discussion.
                 conversationBaseAddress,
                 templatesBaseAddress,
                 _loggerFactory,

--- a/src/Sinch/Verification/SinchEvents/IVerificationSinchEvents.cs
+++ b/src/Sinch/Verification/SinchEvents/IVerificationSinchEvents.cs
@@ -14,7 +14,7 @@ namespace Sinch.Verification.SinchEvents
         /// <param name="body">The raw request body as a string.</param>
         /// <returns>True, if produced signature match with that of a header.</returns>
         bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers,
+            IDictionary<string, IEnumerable<string>> headers,
             string body);
     }
 }

--- a/src/Sinch/Verification/SinchEvents/IVerificationSinchEvents.cs
+++ b/src/Sinch/Verification/SinchEvents/IVerificationSinchEvents.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+
+namespace Sinch.Verification.SinchEvents
+{
+    public interface IVerificationSinchEvents
+    {
+        /// <summary>
+        ///     Validates the authentication header of an incoming Sinch event request.
+        /// </summary>
+        /// <param name="method">The HTTP method of the incoming request (e.g. HttpMethod.Post).</param>
+        /// <param name="path">The request path, e.g. <c>/webhooks/verification</c>.</param>
+        /// <param name="headers">The request headers, used to extract the Authorization signature.</param>
+        /// <param name="body">The raw request body as a string.</param>
+        /// <returns>True, if produced signature match with that of a header.</returns>
+        bool ValidateAuthenticationHeader(HttpMethod method, string path,
+            Dictionary<string, IEnumerable<string>> headers,
+            string body);
+    }
+}

--- a/src/Sinch/Verification/SinchEvents/IVerificationSinchEvents.cs
+++ b/src/Sinch/Verification/SinchEvents/IVerificationSinchEvents.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace Sinch.Verification.SinchEvents

--- a/src/Sinch/Verification/SinchEvents/VerificationSinchEvents.cs
+++ b/src/Sinch/Verification/SinchEvents/VerificationSinchEvents.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Net.Http;
 using Sinch.Auth;
 using Sinch.Core;

--- a/src/Sinch/Verification/SinchEvents/VerificationSinchEvents.cs
+++ b/src/Sinch/Verification/SinchEvents/VerificationSinchEvents.cs
@@ -10,7 +10,7 @@ namespace Sinch.Verification.SinchEvents
         ILoggerAdapter<IVerificationSinchEvents>? logger = null) : IVerificationSinchEvents
     {
         public bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers, string body)
+            IDictionary<string, IEnumerable<string>> headers, string body)
         {
             return AuthorizationHeaderValidation.Validate(method, path, headers, body, applicationSignedAuth, logger);
         }

--- a/src/Sinch/Verification/SinchEvents/VerificationSinchEvents.cs
+++ b/src/Sinch/Verification/SinchEvents/VerificationSinchEvents.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using Sinch.Auth;
+using Sinch.Core;
+using Sinch.Logger;
+
+namespace Sinch.Verification.SinchEvents
+{
+    internal sealed class VerificationSinchEvents(ApplicationSignedAuth applicationSignedAuth,
+        ILoggerAdapter<IVerificationSinchEvents>? logger = null) : IVerificationSinchEvents
+    {
+        public bool ValidateAuthenticationHeader(HttpMethod method, string path,
+            Dictionary<string, IEnumerable<string>> headers, string body)
+        {
+            return AuthorizationHeaderValidation.Validate(method, path, headers, body, applicationSignedAuth, logger);
+        }
+    }
+}

--- a/src/Sinch/Verification/SinchVerificationClient.cs
+++ b/src/Sinch/Verification/SinchVerificationClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using Sinch.Auth;
 using Sinch.Core;
 using Sinch.Logger;
+using Sinch.Verification.SinchEvents;
 
 namespace Sinch.Verification
 {
@@ -23,32 +24,19 @@ namespace Sinch.Verification
         ISinchVerificationStatus VerificationStatus { get; }
 
         /// <summary>
-        ///     Validates the authentication header of an incoming Sinch event request.
+        ///     Parse and validate incoming Verification Sinch event payloads.
         /// </summary>
-        /// <param name="method"></param>
-        /// <param name="path"></param>
-        /// <param name="headers"></param>
-        /// <param name="body"></param>
-        /// <returns>True, if produced signature match with that of a header.</returns>
-        bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers,
-            string body);
+        IVerificationSinchEvents SinchEvents { get; }
     }
 
     internal sealed class SinchVerificationClient : ISinchVerificationClient
     {
-        private readonly ILoggerAdapter<ISinchVerificationClient>? _logger;
-
-        private readonly ApplicationSignedAuth _applicationSignedAuth;
-
         internal SinchVerificationClient(Uri baseAddress, LoggerFactory? loggerFactory,
             IHttp http, ApplicationSignedAuth applicationSignedAuth)
         {
-            _logger = loggerFactory?.Create<ISinchVerificationClient>();
-            _applicationSignedAuth = applicationSignedAuth;
             Verification = new SinchVerification(loggerFactory?.Create<SinchVerification>(), baseAddress, http);
-            VerificationStatus =
-                new SinchVerificationStatus(loggerFactory?.Create<SinchVerificationStatus>(), baseAddress, http);
+            VerificationStatus = new SinchVerificationStatus(loggerFactory?.Create<SinchVerificationStatus>(), baseAddress, http);
+            SinchEvents = new VerificationSinchEvents(applicationSignedAuth, loggerFactory?.Create<IVerificationSinchEvents>());
         }
 
         /// <inheritdoc />
@@ -56,12 +44,8 @@ namespace Sinch.Verification
 
         /// <inheritdoc />
         public ISinchVerificationStatus VerificationStatus { get; }
-
-        public bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers, string body)
-        {
-            return AuthorizationHeaderValidation.Validate(method, path, headers, body, _applicationSignedAuth,
-                _logger);
-        }
+        
+        /// <inheritdoc />
+        public IVerificationSinchEvents SinchEvents { get; }
     }
 }

--- a/src/Sinch/Verification/SinchVerificationClient.cs
+++ b/src/Sinch/Verification/SinchVerificationClient.cs
@@ -42,7 +42,7 @@ namespace Sinch.Verification
 
         /// <inheritdoc />
         public ISinchVerificationStatus VerificationStatus { get; }
-        
+
         /// <inheritdoc />
         public IVerificationSinchEvents SinchEvents { get; }
     }

--- a/src/Sinch/Verification/SinchVerificationClient.cs
+++ b/src/Sinch/Verification/SinchVerificationClient.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using Sinch.Auth;
 using Sinch.Core;
 using Sinch.Logger;

--- a/src/Sinch/Voice/SinchEvents/AnsweredCallEvent.cs
+++ b/src/Sinch/Voice/SinchEvents/AnsweredCallEvent.cs
@@ -13,7 +13,7 @@ namespace Sinch.Voice.SinchEvents
     ///     enabled, the amd object will also be present on ACE callbacks.
     ///     Note: ACE Callbacks are not issued for InApp Calls (destination: username), only PSTN and SIP calls.
     /// </summary>
-    public sealed class AnsweredCallEvent : VoiceSinchEvent
+    public sealed class AnsweredCallEvent : VoiceSinchEventBase
     {
         /// <summary>
         ///     Must have the value ace.

--- a/src/Sinch/Voice/SinchEvents/DisconnectedCallEvent.cs
+++ b/src/Sinch/Voice/SinchEvents/DisconnectedCallEvent.cs
@@ -12,7 +12,7 @@ namespace Sinch.Voice.SinchEvents
     ///     This event doesn't support instructions and only supports the
     ///     [hangup](https://developers.sinch.com/docs/voice/api-reference/svaml/actions/#hangup) action.
     /// </summary>
-    public sealed class DisconnectedCallEvent : VoiceSinchEvent
+    public sealed class DisconnectedCallEvent : VoiceSinchEventBase
     {
         /// <summary>
         ///     Must have the value &#x60;dice&#x60;.

--- a/src/Sinch/Voice/SinchEvents/IVoiceSinchEvent.cs
+++ b/src/Sinch/Voice/SinchEvents/IVoiceSinchEvent.cs
@@ -1,0 +1,12 @@
+using Sinch.Core;
+
+namespace Sinch.Voice.SinchEvents
+{
+    /// <summary>
+    ///     Marker interface for Voice Sinch event types.
+    /// </summary>
+    [JsonInterfaceConverter(typeof(VoiceSinchEventConverter))]
+    public interface IVoiceSinchEvent
+    {
+    }
+}

--- a/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
@@ -48,5 +50,17 @@ namespace Sinch.Voice.SinchEvents
         /// <returns>Parsed Voice Sinch event.</returns>
         /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
         Task<IVoiceSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///     Validates the authentication header of an incoming Voice Sinch event request.
+        /// </summary>
+        /// <param name="method">HTTP method of the incoming request.</param>
+        /// <param name="path">Path of the incoming request (e.g. <c>/webhooks/voice</c>).</param>
+        /// <param name="headers">Headers from the incoming request.</param>
+        /// <param name="body">Raw request body string.</param>
+        /// <returns><see langword="true"/> if the computed signature matches the Authorization header; otherwise <see langword="false"/>.</returns>
+        bool ValidateAuthenticationHeader(HttpMethod method, string path,
+            Dictionary<string, IEnumerable<string>> headers,
+            string body);
     }
 }

--- a/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -33,14 +32,6 @@ namespace Sinch.Voice.SinchEvents
         /// <exception cref="System.Text.Json.JsonException">Thrown when JSON is invalid or cannot be deserialized.</exception>
         /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
         IVoiceSinchEvent ParseEvent(string json);
-
-        /// <summary>
-        ///     Parses a Voice Sinch event from a <see cref="JsonNode"/>.
-        /// </summary>
-        /// <param name="json">The parsed JSON node from the Voice Sinch event request body.</param>
-        /// <returns>Parsed Voice Sinch event.</returns>
-        /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
-        IVoiceSinchEvent ParseEvent(JsonNode json);
 
         /// <summary>
         ///     Parses a Voice Sinch event from a stream.

--- a/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
@@ -1,0 +1,52 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Sinch.Voice.SinchEvents
+{
+    /// <summary>
+    ///     Voice Sinch Events service. Provides helpers for parsing
+    ///     incoming Voice Sinch event payloads delivered by the Voice API.
+    /// </summary>
+    public interface IVoiceSinchEvents
+    {
+        JsonSerializerOptions JsonSerializerOptions { get; }
+
+        /// <summary>
+        ///     Parses a Voice Sinch event from a JSON string.
+        /// </summary>
+        /// <param name="json">The raw JSON payload from the Voice Sinch event request body.</param>
+        /// <returns>
+        ///     Parsed Voice Sinch event. Use pattern matching to handle specific event types:
+        ///     <list type="bullet">
+        ///         <item><description><see cref="IncomingCallEvent"/> — An incoming call (ICE).</description></item>
+        ///         <item><description><see cref="AnsweredCallEvent"/> — A call was answered (ACE).</description></item>
+        ///         <item><description><see cref="DisconnectedCallEvent"/> — A call was disconnected (DICE).</description></item>
+        ///         <item><description><see cref="PromptInputEvent"/> — Prompt input received (PIE).</description></item>
+        ///         <item><description><see cref="NotificationEvent"/> — A general notification (notify).</description></item>
+        ///     </list>
+        /// </returns>
+        /// <exception cref="System.Text.Json.JsonException">Thrown when JSON is invalid or cannot be deserialized.</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
+        IVoiceSinchEvent ParseEvent(string json);
+
+        /// <summary>
+        ///     Parses a Voice Sinch event from a <see cref="JsonNode"/>.
+        /// </summary>
+        /// <param name="json">The parsed JSON node from the Voice Sinch event request body.</param>
+        /// <returns>Parsed Voice Sinch event.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
+        IVoiceSinchEvent ParseEvent(JsonNode json);
+
+        /// <summary>
+        ///     Parses a Voice Sinch event from a stream.
+        /// </summary>
+        /// <param name="json">A stream containing the JSON payload from the Voice Sinch event request body.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>Parsed Voice Sinch event.</returns>
+        /// <exception cref="System.InvalidOperationException">Thrown when the event type is unknown or deserialization fails.</exception>
+        Task<IVoiceSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/IVoiceSinchEvents.cs
@@ -51,7 +51,7 @@ namespace Sinch.Voice.SinchEvents
         /// <param name="body">Raw request body string.</param>
         /// <returns><see langword="true"/> if the computed signature matches the Authorization header; otherwise <see langword="false"/>.</returns>
         bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers,
+            IDictionary<string, IEnumerable<string>> headers,
             string body);
     }
 }

--- a/src/Sinch/Voice/SinchEvents/IncomingCallEvent.cs
+++ b/src/Sinch/Voice/SinchEvents/IncomingCallEvent.cs
@@ -15,7 +15,7 @@ namespace Sinch.Voice.SinchEvents
     ///     If there is no response to the callback within the timeout period, an error message is played, and the call is
     ///     disconnected.
     /// </summary>
-    public sealed class IncomingCallEvent : VoiceSinchEvent
+    public sealed class IncomingCallEvent : VoiceSinchEventBase
     {
         /// <summary>
         ///     Must have the value ice.

--- a/src/Sinch/Voice/SinchEvents/NotificationEvent.cs
+++ b/src/Sinch/Voice/SinchEvents/NotificationEvent.cs
@@ -8,7 +8,7 @@ namespace Sinch.Voice.SinchEvents
     ///     <br /><br />
     ///     If there is no response to the callback within the timeout period, the notification is discarded.
     /// </summary>
-    public sealed class NotificationEvent : VoiceSinchEvent
+    public sealed class NotificationEvent : VoiceSinchEventBase
     {
         /// <summary>
         ///     Must have the value notify.

--- a/src/Sinch/Voice/SinchEvents/PromptInputEvent.cs
+++ b/src/Sinch/Voice/SinchEvents/PromptInputEvent.cs
@@ -13,7 +13,7 @@ namespace Sinch.Voice.SinchEvents
     ///     [SVAML](https://developers.sinch.com/docs/voice/api-reference/svaml/) logic.<br /><br />
     ///     Note: PIE callbacks are not issued for DATA Calls, only PSTN and SIP calls.
     /// </summary>
-    public sealed class PromptInputEvent : VoiceSinchEvent
+    public sealed class PromptInputEvent : VoiceSinchEventBase
     {
         /// <summary>
         ///     Must have the value pie.

--- a/src/Sinch/Voice/SinchEvents/VoiceSinchEventBase.cs
+++ b/src/Sinch/Voice/SinchEvents/VoiceSinchEventBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.SinchEvents
 {

--- a/src/Sinch/Voice/SinchEvents/VoiceSinchEventBase.cs
+++ b/src/Sinch/Voice/SinchEvents/VoiceSinchEventBase.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Sinch.Voice.SinchEvents
+{
+    /// <summary>
+    ///     Base class for Voice Sinch event types. Use <see cref="IVoiceSinchEvent"/> in public API.
+    /// </summary>
+    public abstract class VoiceSinchEventBase : IVoiceSinchEvent
+    {
+        [JsonPropertyName("event")]
+        [JsonInclude]
+        internal abstract EventType Event { get; set; }
+    }
+}

--- a/src/Sinch/Voice/SinchEvents/VoiceSinchEventConverter.cs
+++ b/src/Sinch/Voice/SinchEvents/VoiceSinchEventConverter.cs
@@ -5,20 +5,9 @@ using System.Text.Json.Serialization;
 
 namespace Sinch.Voice.SinchEvents
 {
-    /// <summary>
-    ///     Marker interface for event types of voice.
-    /// </summary>
-    [JsonConverter(typeof(VoiceSinchEventConverter))]
-    public abstract class VoiceSinchEvent
+    public sealed class VoiceSinchEventConverter : JsonConverter<IVoiceSinchEvent>
     {
-        [JsonPropertyName("event")]
-        [JsonInclude]
-        internal abstract EventType Event { get; set; }
-    }
-
-    public sealed class VoiceSinchEventConverter : JsonConverter<VoiceSinchEvent>
-    {
-        public override VoiceSinchEvent? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        public override IVoiceSinchEvent? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var elem = JsonElement.ParseValue(ref reader);
             var descriptor = elem.EnumerateObject().FirstOrDefault(x => x.Name == "event");
@@ -52,7 +41,7 @@ namespace Sinch.Voice.SinchEvents
             throw new JsonException($"Failed to match verification method object, got {descriptor.Name}");
         }
 
-        public override void Write(Utf8JsonWriter writer, VoiceSinchEvent value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, IVoiceSinchEvent value, JsonSerializerOptions options)
         {
             switch (value)
             {
@@ -73,7 +62,7 @@ namespace Sinch.Voice.SinchEvents
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(value),
-                        $"Cannot find a matching class for the interface {nameof(VoiceSinchEvent)}");
+                        $"Cannot find a matching class for the interface {nameof(IVoiceSinchEvent)}");
             }
         }
     }

--- a/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
@@ -1,0 +1,64 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Sinch.Logger;
+
+namespace Sinch.Voice.SinchEvents
+{
+    /// <inheritdoc />
+    internal sealed class VoiceSinchEvents(
+        JsonSerializerOptions jsonSerializerOptions,
+        ILoggerAdapter<IVoiceSinchEvents>? logger = null)
+        : IVoiceSinchEvents
+    {
+        public JsonSerializerOptions JsonSerializerOptions { get; } = jsonSerializerOptions;
+
+        /// <inheritdoc />
+        public IVoiceSinchEvent ParseEvent(string json)
+        {
+            var result = JsonSerializer.Deserialize<IVoiceSinchEvent>(json, JsonSerializerOptions);
+            if (result == null)
+            {
+                logger?.LogError(
+                    "Failed to deserialize Voice Sinch event. No matching event type found for payload: {json}", json);
+                throw new InvalidOperationException("Deserialization of Voice Sinch event failed");
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public IVoiceSinchEvent ParseEvent(JsonNode json)
+        {
+            var result = json.Deserialize<IVoiceSinchEvent>(JsonSerializerOptions);
+            if (result == null)
+            {
+                logger?.LogError(
+                    "Failed to deserialize Voice Sinch event. No matching event type found for payload: {json}",
+                    json.ToJsonString());
+                throw new InvalidOperationException("Deserialization of Voice Sinch event failed");
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public async Task<IVoiceSinchEvent> ParseEventAsync(Stream jsonStream,
+            CancellationToken cancellationToken = default)
+        {
+            var result =
+                await JsonSerializer.DeserializeAsync<IVoiceSinchEvent>(jsonStream, JsonSerializerOptions,
+                    cancellationToken);
+            if (result == null)
+            {
+                logger?.LogError("Failed to deserialize Voice Sinch event. No matching event type found.");
+                throw new InvalidOperationException("Deserialization of Voice Sinch event failed");
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
@@ -52,7 +52,7 @@ namespace Sinch.Voice.SinchEvents
 
         /// <inheritdoc />
         public bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers, string body)
+            IDictionary<string, IEnumerable<string>> headers, string body)
         {
             return AuthorizationHeaderValidation.Validate(method, path, headers, body, applicationSignedAuth, logger);
         }

--- a/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using Sinch.Auth;
+using Sinch.Core;
 using Sinch.Logger;
 
 namespace Sinch.Voice.SinchEvents
@@ -11,6 +15,7 @@ namespace Sinch.Voice.SinchEvents
     /// <inheritdoc />
     internal sealed class VoiceSinchEvents(
         JsonSerializerOptions jsonSerializerOptions,
+        ApplicationSignedAuth applicationSignedAuth,
         ILoggerAdapter<IVoiceSinchEvents>? logger = null)
         : IVoiceSinchEvents
     {
@@ -59,6 +64,13 @@ namespace Sinch.Voice.SinchEvents
             }
 
             return result;
+        }
+
+        /// <inheritdoc />
+        public bool ValidateAuthenticationHeader(HttpMethod method, string path,
+            Dictionary<string, IEnumerable<string>> headers, string body)
+        {
+            return AuthorizationHeaderValidation.Validate(method, path, headers, body, applicationSignedAuth, logger);
         }
     }
 }

--- a/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
+++ b/src/Sinch/Voice/SinchEvents/VoiceSinchEvents.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Sinch.Auth;
@@ -29,21 +28,6 @@ namespace Sinch.Voice.SinchEvents
             {
                 logger?.LogError(
                     "Failed to deserialize Voice Sinch event. No matching event type found for payload: {json}", json);
-                throw new InvalidOperationException("Deserialization of Voice Sinch event failed");
-            }
-
-            return result;
-        }
-
-        /// <inheritdoc />
-        public IVoiceSinchEvent ParseEvent(JsonNode json)
-        {
-            var result = json.Deserialize<IVoiceSinchEvent>(JsonSerializerOptions);
-            if (result == null)
-            {
-                logger?.LogError(
-                    "Failed to deserialize Voice Sinch event. No matching event type found for payload: {json}",
-                    json.ToJsonString());
                 throw new InvalidOperationException("Deserialization of Voice Sinch event failed");
             }
 

--- a/src/Sinch/Voice/SinchVoiceClient.cs
+++ b/src/Sinch/Voice/SinchVoiceClient.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Net.Http;
 using Sinch.Auth;
 using Sinch.Core;
 using Sinch.Logger;
@@ -39,38 +37,21 @@ namespace Sinch.Voice
         ///     Parse and validate incoming Voice Sinch event payloads.
         /// </summary>
         IVoiceSinchEvents SinchEvents { get; }
-
-        /// <summary>
-        ///     Validates the authentication header of an incoming Sinch event request.
-        /// </summary>
-        /// <param name="method"></param>
-        /// <param name="path"></param>
-        /// <param name="headers"></param>
-        /// <param name="body"></param>
-        /// <returns>True, if produced signature match with that of a header.</returns>
-        bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers,
-            string body);
     }
 
     /// <inheritdoc />
     internal sealed class SinchVoiceClient : ISinchVoiceClient
     {
-        private readonly ApplicationSignedAuth _applicationSignedAuth;
-        private readonly ILoggerAdapter<ISinchVoiceClient>? _logger;
-
         public SinchVoiceClient(Uri baseAddress, LoggerFactory? loggerFactory,
             IHttp http, ApplicationSignedAuth applicationSignedAuth, Uri applicationManagementBaseAddress)
         {
-            _applicationSignedAuth = applicationSignedAuth;
-            _logger = loggerFactory?.Create<ISinchVoiceClient>();
             Callouts = new SinchCallout(loggerFactory?.Create<ISinchVoiceCallout>(), baseAddress, http);
             Calls = new SinchCalls(loggerFactory?.Create<ISinchVoiceCalls>(), baseAddress, http);
             Conferences = new SinchConferences(loggerFactory?.Create<ISinchVoiceConferences>(), baseAddress, http,
                 Callouts);
             Applications = new SinchApplications(loggerFactory?.Create<ISinchVoiceApplications>(),
                 applicationManagementBaseAddress, http);
-            SinchEvents = new VoiceSinchEvents(http.JsonSerializerOptions,
+            SinchEvents = new VoiceSinchEvents(http.JsonSerializerOptions, applicationSignedAuth,
                 loggerFactory?.Create<IVoiceSinchEvents>());
         }
 
@@ -88,12 +69,5 @@ namespace Sinch.Voice
 
         /// <inheritdoc />
         public IVoiceSinchEvents SinchEvents { get; }
-
-        public bool ValidateAuthenticationHeader(HttpMethod method, string path,
-            Dictionary<string, IEnumerable<string>> headers, string body)
-        {
-            return AuthorizationHeaderValidation.Validate(method, path, headers, body, _applicationSignedAuth,
-                _logger);
-        }
     }
 }

--- a/src/Sinch/Voice/SinchVoiceClient.cs
+++ b/src/Sinch/Voice/SinchVoiceClient.cs
@@ -1,11 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Net.Http;
-using System.Text.Json;
-using System.Text.Json.Nodes;
-using System.Threading;
-using System.Threading.Tasks;
 using Sinch.Auth;
 using Sinch.Core;
 using Sinch.Logger;
@@ -41,6 +36,11 @@ namespace Sinch.Voice
         ISinchVoiceApplications Applications { get; }
 
         /// <summary>
+        ///     Parse and validate incoming Voice Sinch event payloads.
+        /// </summary>
+        IVoiceSinchEvents SinchEvents { get; }
+
+        /// <summary>
         ///     Validates the authentication header of an incoming Sinch event request.
         /// </summary>
         /// <param name="method"></param>
@@ -51,28 +51,6 @@ namespace Sinch.Voice
         bool ValidateAuthenticationHeader(HttpMethod method, string path,
             Dictionary<string, IEnumerable<string>> headers,
             string body);
-
-        /// <summary>
-        ///     Parses a Voice Sinch event from a JSON string.
-        /// </summary>
-        /// <param name="json"></param>
-        /// <returns></returns>
-        VoiceSinchEvent ParseEvent(string json);
-
-        /// <summary>
-        ///     Parses a Voice Sinch event from a JSON node.
-        /// </summary>
-        /// <param name="json"></param>
-        /// <returns></returns>
-        VoiceSinchEvent ParseEvent(JsonNode json);
-
-        /// <summary>
-        ///     Parses a Voice Sinch event from a stream.
-        /// </summary>
-        /// <param name="json"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task<VoiceSinchEvent> ParseEventAsync(Stream json, CancellationToken cancellationToken = default);
     }
 
     /// <inheritdoc />
@@ -80,12 +58,10 @@ namespace Sinch.Voice
     {
         private readonly ApplicationSignedAuth _applicationSignedAuth;
         private readonly ILoggerAdapter<ISinchVoiceClient>? _logger;
-        private readonly JsonSerializerOptions _jsonSerializerOptions;
 
         public SinchVoiceClient(Uri baseAddress, LoggerFactory? loggerFactory,
             IHttp http, ApplicationSignedAuth applicationSignedAuth, Uri applicationManagementBaseAddress)
         {
-            _jsonSerializerOptions = http.JsonSerializerOptions;
             _applicationSignedAuth = applicationSignedAuth;
             _logger = loggerFactory?.Create<ISinchVoiceClient>();
             Callouts = new SinchCallout(loggerFactory?.Create<ISinchVoiceCallout>(), baseAddress, http);
@@ -94,6 +70,8 @@ namespace Sinch.Voice
                 Callouts);
             Applications = new SinchApplications(loggerFactory?.Create<ISinchVoiceApplications>(),
                 applicationManagementBaseAddress, http);
+            SinchEvents = new VoiceSinchEvents(http.JsonSerializerOptions,
+                loggerFactory?.Create<IVoiceSinchEvents>());
         }
 
         /// <inheritdoc />
@@ -108,47 +86,14 @@ namespace Sinch.Voice
         /// <inheritdoc />
         public ISinchVoiceApplications Applications { get; }
 
+        /// <inheritdoc />
+        public IVoiceSinchEvents SinchEvents { get; }
+
         public bool ValidateAuthenticationHeader(HttpMethod method, string path,
             Dictionary<string, IEnumerable<string>> headers, string body)
         {
             return AuthorizationHeaderValidation.Validate(method, path, headers, body, _applicationSignedAuth,
                 _logger);
-        }
-
-        public VoiceSinchEvent ParseEvent(string json)
-        {
-            var jsonResult = JsonSerializer.Deserialize<VoiceSinchEvent>(json, _jsonSerializerOptions);
-            if (jsonResult == null)
-            {
-                throw new InvalidOperationException("Deserialization of Voice event failed");
-            }
-
-            return jsonResult;
-        }
-
-        public VoiceSinchEvent ParseEvent(JsonNode json)
-        {
-            var jsonResult = json.Deserialize<VoiceSinchEvent>(_jsonSerializerOptions);
-            if (jsonResult == null)
-            {
-                throw new InvalidOperationException("Deserialization of Voice event failed");
-            }
-
-            return jsonResult;
-        }
-
-        public async Task<VoiceSinchEvent> ParseEventAsync(Stream jsonStream,
-            CancellationToken cancellationToken = default)
-        {
-            var jsonResult =
-                await JsonSerializer.DeserializeAsync<VoiceSinchEvent>(jsonStream, _jsonSerializerOptions,
-                    cancellationToken);
-            if (jsonResult == null)
-            {
-                throw new InvalidOperationException("Deserialization of Voice event failed");
-            }
-
-            return jsonResult;
         }
     }
 }

--- a/tests/Sinch.Tests.Features/Conversation/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Conversation/SinchEvents.cs
@@ -3,7 +3,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
-using Sinch.Conversation.EventDestinations;
 using Sinch.Conversation.SinchEvents;
 using Sinch.Conversation.SinchEvents.Models;
 
@@ -17,7 +16,7 @@ public class SinchEvents
     private const string BaseEventDestinationsUrl = "http://localhost:3014/webhooks/conversation";
 
     private readonly HttpClient _httpClient = new();
-    private ISinchConversationEventDestinations _eventDestinations;
+    private IConversationSinchEvents _eventDestinations;
     private HttpResponseMessage _eventResponse;
     private string _rawEvent;
     private IConversationSinchEvent _parsedEvent;
@@ -25,7 +24,7 @@ public class SinchEvents
     [Given(@"the Conversation Webhooks handler is available")]
     public void GivenTheConversationEventDestinationsHandlerIsAvailable()
     {
-        _eventDestinations = Utils.SinchConversationClient().EventDestinations;
+        _eventDestinations = Utils.SinchConversationClient().SinchEvents;
     }
 
     [When(@"I send a request to trigger a ""(.*)"" event")]

--- a/tests/Sinch.Tests.Features/Conversation/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Conversation/SinchEvents.cs
@@ -16,7 +16,7 @@ public class SinchEvents
     private const string BaseEventDestinationsUrl = "http://localhost:3014/webhooks/conversation";
 
     private readonly HttpClient _httpClient = new();
-    private IConversationSinchEvents _sinchEvents;
+    private IConversationSinchEvents _conversationSinchEvents;
     private HttpResponseMessage _eventResponse;
     private string _rawEvent;
     private IConversationSinchEvent _parsedEvent;
@@ -24,7 +24,7 @@ public class SinchEvents
     [Given(@"the Conversation Webhooks handler is available")]
     public void GivenTheConversationEventDestinationsHandlerIsAvailable()
     {
-        _sinchEvents = new ConversationSinchEvents(Sinch.Conversation.SinchConversationClient.JsonSerializerOptionsInner);
+        _conversationSinchEvents = new ConversationSinchEvents(Sinch.Conversation.SinchConversationClient.JsonSerializerOptionsInner);
     }
 
     [When(@"I send a request to trigger a ""(.*)"" event")]
@@ -137,12 +137,12 @@ public class SinchEvents
         _eventResponse.EnsureSuccessStatusCode();
 
         _rawEvent = await _eventResponse.Content.ReadAsStringAsync();
-        _parsedEvent = _sinchEvents.ParseEvent(_rawEvent);
+        _parsedEvent = _conversationSinchEvents.ParseEvent(_rawEvent);
     }
 
     private void ValidateAuthenticationHeader()
     {
-        _sinchEvents.ValidateAuthenticationHeader(_eventResponse.GetAllHeaders(), _rawEvent, SinchEventSecret)
+        _conversationSinchEvents.ValidateAuthenticationHeader(_eventResponse.GetAllHeaders(), _rawEvent, SinchEventSecret)
             .Should()
             .BeTrue();
     }

--- a/tests/Sinch.Tests.Features/Conversation/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Conversation/SinchEvents.cs
@@ -16,7 +16,7 @@ public class SinchEvents
     private const string BaseEventDestinationsUrl = "http://localhost:3014/webhooks/conversation";
 
     private readonly HttpClient _httpClient = new();
-    private IConversationSinchEvents _eventDestinations;
+    private IConversationSinchEvents _sinchEvents;
     private HttpResponseMessage _eventResponse;
     private string _rawEvent;
     private IConversationSinchEvent _parsedEvent;
@@ -24,7 +24,7 @@ public class SinchEvents
     [Given(@"the Conversation Webhooks handler is available")]
     public void GivenTheConversationEventDestinationsHandlerIsAvailable()
     {
-        _eventDestinations = Utils.SinchConversationClient().SinchEvents;
+        _sinchEvents = new ConversationSinchEvents(Sinch.Conversation.SinchConversationClient.JsonSerializerOptionsInner);
     }
 
     [When(@"I send a request to trigger a ""(.*)"" event")]
@@ -137,12 +137,12 @@ public class SinchEvents
         _eventResponse.EnsureSuccessStatusCode();
 
         _rawEvent = await _eventResponse.Content.ReadAsStringAsync();
-        _parsedEvent = _eventDestinations.ParseEvent(_rawEvent);
+        _parsedEvent = _sinchEvents.ParseEvent(_rawEvent);
     }
 
     private void ValidateAuthenticationHeader()
     {
-        _eventDestinations.ValidateAuthenticationHeader(_eventResponse.GetAllHeaders(), _rawEvent, SinchEventSecret)
+        _sinchEvents.ValidateAuthenticationHeader(_eventResponse.GetAllHeaders(), _rawEvent, SinchEventSecret)
             .Should()
             .BeTrue();
     }

--- a/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
@@ -1,6 +1,5 @@
 using System.Net.Http;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;

--- a/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
@@ -1,5 +1,4 @@
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
@@ -34,7 +33,7 @@ namespace Sinch.Tests.Features.Numbers
         public async Task ThenTheHeaderOfTheForEventContainsAValidSignature(string success, string p1)
         {
             _rawData = await _eventResponse.Content.ReadAsStringAsync();
-            _sinchNumbers.ValidateAuthenticationHeader(SinchEventSecret, _rawData, _eventResponse.Headers)
+            _sinchNumbers.SinchEvents.ValidateAuthenticationHeader(SinchEventSecret, _rawData, _eventResponse.Headers)
                 .Should()
                 .BeTrue();
         }
@@ -42,7 +41,7 @@ namespace Sinch.Tests.Features.Numbers
         [Then(@"the event describes a ""success"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
         public void ThenTheEventDescribesAForEvent()
         {
-            var parsedEvent = JsonSerializer.Deserialize<NumberSinchEvent>(_rawData);
+            var parsedEvent = _sinchNumbers.SinchEvents.ParseEvent(_rawData);
             parsedEvent.EventType.Should().Be(EventType.ProvisioningToVoicePlatform);
             parsedEvent.Status.Should().Be(EventStatus.Succeeded);
             parsedEvent.FailureCode.Should().BeNull();
@@ -58,7 +57,7 @@ namespace Sinch.Tests.Features.Numbers
         [Then(@"the event describes a ""failure"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
         public void ThenTheEventDescribesAFailureForEvent()
         {
-            var parsedEvent = JsonSerializer.Deserialize<NumberSinchEvent>(_rawData);
+            var parsedEvent = _sinchNumbers.SinchEvents.ParseEvent(_rawData);
             parsedEvent.EventType.Should().Be(EventType.ProvisioningToVoicePlatform);
             parsedEvent.Status.Should().Be(EventStatus.Failed);
             parsedEvent.FailureCode.Should().Be(FailureCode.ProvisioningToVoicePlatformFailed);

--- a/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
@@ -12,7 +12,7 @@ namespace Sinch.Tests.Features.Numbers
     [Binding]
     public class SinchEvents
     {
-        private INumbersSinchEvents _sinchEvents;
+        private INumbersSinchEvents _numbersSinchEvents;
         private readonly HttpClient _httpClient = new();
         private HttpResponseMessage _eventResponse;
         private string _rawData;
@@ -21,12 +21,8 @@ namespace Sinch.Tests.Features.Numbers
         [Given(@"the Numbers Webhooks handler is available")]
         public void GivenTheNumbersSinchEventsHandlerIsAvailable()
         {
-            _sinchEvents = new NumbersSinchEvents(
-                new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                }, null);
+            _numbersSinchEvents = new NumbersSinchEvents(
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
         }
 
         [When(@"I send a request to trigger the ""success"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
@@ -40,7 +36,7 @@ namespace Sinch.Tests.Features.Numbers
         public async Task ThenTheHeaderOfTheForEventContainsAValidSignature(string success, string p1)
         {
             _rawData = await _eventResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(SinchEventSecret, _rawData, _eventResponse.Headers)
+            _numbersSinchEvents.ValidateAuthenticationHeader(SinchEventSecret, _rawData, _eventResponse.Headers)
                 .Should()
                 .BeTrue();
         }
@@ -48,7 +44,7 @@ namespace Sinch.Tests.Features.Numbers
         [Then(@"the event describes a ""success"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
         public void ThenTheEventDescribesAForEvent()
         {
-            var parsedEvent = _sinchEvents.ParseEvent(_rawData);
+            var parsedEvent = _numbersSinchEvents.ParseEvent(_rawData);
             parsedEvent.EventType.Should().Be(EventType.ProvisioningToVoicePlatform);
             parsedEvent.Status.Should().Be(EventStatus.Succeeded);
             parsedEvent.FailureCode.Should().BeNull();
@@ -64,7 +60,7 @@ namespace Sinch.Tests.Features.Numbers
         [Then(@"the event describes a ""failure"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
         public void ThenTheEventDescribesAFailureForEvent()
         {
-            var parsedEvent = _sinchEvents.ParseEvent(_rawData);
+            var parsedEvent = _numbersSinchEvents.ParseEvent(_rawData);
             parsedEvent.EventType.Should().Be(EventType.ProvisioningToVoicePlatform);
             parsedEvent.Status.Should().Be(EventStatus.Failed);
             parsedEvent.FailureCode.Should().Be(FailureCode.ProvisioningToVoicePlatformFailed);

--- a/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Numbers/SinchEvents.cs
@@ -1,4 +1,6 @@
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
@@ -10,7 +12,7 @@ namespace Sinch.Tests.Features.Numbers
     [Binding]
     public class SinchEvents
     {
-        private ISinchNumbers _sinchNumbers;
+        private INumbersSinchEvents _sinchEvents;
         private readonly HttpClient _httpClient = new();
         private HttpResponseMessage _eventResponse;
         private string _rawData;
@@ -19,7 +21,12 @@ namespace Sinch.Tests.Features.Numbers
         [Given(@"the Numbers Webhooks handler is available")]
         public void GivenTheNumbersSinchEventsHandlerIsAvailable()
         {
-            _sinchNumbers = Utils.SinchNumbersClient();
+            _sinchEvents = new NumbersSinchEvents(
+                new JsonSerializerOptions(JsonSerializerDefaults.Web)
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                }, null);
         }
 
         [When(@"I send a request to trigger the ""success"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
@@ -33,7 +40,7 @@ namespace Sinch.Tests.Features.Numbers
         public async Task ThenTheHeaderOfTheForEventContainsAValidSignature(string success, string p1)
         {
             _rawData = await _eventResponse.Content.ReadAsStringAsync();
-            _sinchNumbers.SinchEvents.ValidateAuthenticationHeader(SinchEventSecret, _rawData, _eventResponse.Headers)
+            _sinchEvents.ValidateAuthenticationHeader(SinchEventSecret, _rawData, _eventResponse.Headers)
                 .Should()
                 .BeTrue();
         }
@@ -41,7 +48,7 @@ namespace Sinch.Tests.Features.Numbers
         [Then(@"the event describes a ""success"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
         public void ThenTheEventDescribesAForEvent()
         {
-            var parsedEvent = _sinchNumbers.SinchEvents.ParseEvent(_rawData);
+            var parsedEvent = _sinchEvents.ParseEvent(_rawData);
             parsedEvent.EventType.Should().Be(EventType.ProvisioningToVoicePlatform);
             parsedEvent.Status.Should().Be(EventStatus.Succeeded);
             parsedEvent.FailureCode.Should().BeNull();
@@ -57,7 +64,7 @@ namespace Sinch.Tests.Features.Numbers
         [Then(@"the event describes a ""failure"" for ""PROVISIONING_TO_VOICE_PLATFORM"" event")]
         public void ThenTheEventDescribesAFailureForEvent()
         {
-            var parsedEvent = _sinchNumbers.SinchEvents.ParseEvent(_rawData);
+            var parsedEvent = _sinchEvents.ParseEvent(_rawData);
             parsedEvent.EventType.Should().Be(EventType.ProvisioningToVoicePlatform);
             parsedEvent.Status.Should().Be(EventStatus.Failed);
             parsedEvent.FailureCode.Should().Be(FailureCode.ProvisioningToVoicePlatformFailed);

--- a/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;

--- a/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
@@ -32,7 +32,7 @@ namespace Sinch.Tests.Features.Sms
         [Given(@"the SMS Webhooks handler is available")]
         public void GivenTheSmsSinchEventsHandlerIsAvailable()
         {
-            _smsSinchEvents = Utils.SinchClient.Sms.SmsSinchEvents;
+            _smsSinchEvents = Utils.SinchClient.Sms.SinchEvents;
         }
 
         [When(@"I send a request to trigger an ""incoming SMS"" event")]

--- a/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
@@ -32,7 +33,12 @@ namespace Sinch.Tests.Features.Sms
         [Given(@"the SMS Webhooks handler is available")]
         public void GivenTheSmsSinchEventsHandlerIsAvailable()
         {
-            _smsSinchEvents = Utils.SinchClient.Sms.SinchEvents;
+            _smsSinchEvents = new SmsSinchEvents(
+                new JsonSerializerOptions(JsonSerializerDefaults.Web)
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                });
         }
 
         [When(@"I send a request to trigger an ""incoming SMS"" event")]

--- a/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
@@ -34,11 +34,7 @@ namespace Sinch.Tests.Features.Sms
         public void GivenTheSmsSinchEventsHandlerIsAvailable()
         {
             _smsSinchEvents = new SmsSinchEvents(
-                new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                });
+                new JsonSerializerOptions(JsonSerializerDefaults.Web));
         }
 
         [When(@"I send a request to trigger an ""incoming SMS"" event")]

--- a/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Sms/SinchEvents.cs
@@ -175,7 +175,7 @@ namespace Sinch.Tests.Features.Sms
         {
             var headers = response.Headers.ToDictionary(
                 x => x.Key,
-                x => x.Value.FirstOrDefault(),
+                x => x.Value,
                 StringComparer.OrdinalIgnoreCase);
 
             var body = await response.Content.ReadAsStringAsync();

--- a/tests/Sinch.Tests.Features/Verification/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Verification/SinchEvents.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
+using Sinch.Auth;
 using Sinch.Verification;
 using Sinch.Verification.Common;
 using Sinch.Verification.SinchEvents;
@@ -12,16 +13,19 @@ namespace Sinch.Tests.Features.Verification
     [Binding]
     public class SinchEvents
     {
-        private readonly HttpClient _httpClient = new HttpClient();
+        private readonly HttpClient _httpClient = new();
         private HttpResponseMessage _verificationRequestResponseMessage;
         private HttpResponseMessage _verificationResultResponse;
-        private ISinchVerificationClient _sinchVerificationClient;
         private string _rawBody;
+        
+        private static readonly ApplicationSignedAuth ApplicationSignedAuth =
+            new("appKey", "YXBwU2VjcmV0");
+        private VerificationSinchEvents _verificationSinchEvents = new(ApplicationSignedAuth);
 
         [Given(@"the Verification Webhooks handler is available")]
         public void GivenTheVerificationSinchEventsHandlerIsAvailable()
         {
-            _sinchVerificationClient = Utils.SinchVerificationClient;
+            _verificationSinchEvents = new(ApplicationSignedAuth);
         }
 
         [When(@"I send a request to trigger a ""Verification Request"" event")]
@@ -35,7 +39,7 @@ namespace Sinch.Tests.Features.Verification
         public async Task ThenTheHeaderOfTheVerificationEventContainsAValidAuthorization()
         {
             _rawBody = await _verificationRequestResponseMessage.Content.ReadAsStringAsync();
-            _sinchVerificationClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/verification",
+            _verificationSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/verification",
                 _verificationRequestResponseMessage.GetAllHeaders(),
                 _rawBody).Should().BeTrue();
         }
@@ -70,7 +74,7 @@ namespace Sinch.Tests.Features.Verification
         public async Task ThenTheHeaderOfTheVerificationResultEventContainsAValidAuthorization()
         {
             _rawBody = await _verificationResultResponse.Content.ReadAsStringAsync();
-            _sinchVerificationClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/verification",
+            _verificationSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/verification",
                 _verificationResultResponse.GetAllHeaders(),
                 _rawBody).Should().BeTrue();
         }

--- a/tests/Sinch.Tests.Features/Verification/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Verification/SinchEvents.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
 using Sinch.Auth;
-using Sinch.Verification;
 using Sinch.Verification.Common;
 using Sinch.Verification.SinchEvents;
 
@@ -17,7 +16,7 @@ namespace Sinch.Tests.Features.Verification
         private HttpResponseMessage _verificationRequestResponseMessage;
         private HttpResponseMessage _verificationResultResponse;
         private string _rawBody;
-        
+
         private static readonly ApplicationSignedAuth ApplicationSignedAuth =
             new("appKey", "YXBwU2VjcmV0");
         private VerificationSinchEvents _verificationSinchEvents = new(ApplicationSignedAuth);

--- a/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
@@ -1,6 +1,5 @@
 using System.Net.Http;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;

--- a/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
@@ -71,7 +71,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""PIE"" event with a ""return"" type")]
         public void ThenTheVoiceEventDescribesAEventWithAType()
         {
-            _voiceClient.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
+            _voiceClient.SinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
                 new PromptInputEvent
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000013",
@@ -107,7 +107,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""PIE"" event with a ""sequence"" type")]
         public void ThenTheVoiceEventDescribesAPieEventWithASequenceType()
         {
-            _voiceClient.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
+            _voiceClient.SinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
                 new PromptInputEvent
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000023",
@@ -143,7 +143,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""DICE"" event")]
         public void ThenTheVoiceEventDescribesAEvent()
         {
-            _voiceClient.ParseEvent(_rawDiceContent).Should().BeEquivalentTo(new DisconnectedCallEvent
+            _voiceClient.SinchEvents.ParseEvent(_rawDiceContent).Should().BeEquivalentTo(new DisconnectedCallEvent
             {
                 CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000033",
                 Timestamp = Helpers.ParseUtc("2024-06-06T16:59:42Z"),
@@ -190,7 +190,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""ACE"" event")]
         public void ThenTheVoiceEventDescribesAceEvent()
         {
-            _voiceClient.ParseEvent(_rawAceContent).Should().BeEquivalentTo(new AnsweredCallEvent
+            _voiceClient.SinchEvents.ParseEvent(_rawAceContent).Should().BeEquivalentTo(new AnsweredCallEvent
             {
                 CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000043",
                 CallResourceUrl = null,
@@ -220,7 +220,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""ICE"" event")]
         public void ThenTheVoiceEventDescribesAIceEvent()
         {
-            _voiceClient.ParseEvent(_rawIceContent).As<IncomingCallEvent>().Should().BeEquivalentTo(
+            _voiceClient.SinchEvents.ParseEvent(_rawIceContent).As<IncomingCallEvent>().Should().BeEquivalentTo(
                 new IncomingCallEvent()
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000053",
@@ -265,7 +265,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""recording_finished"" type")]
         public void ThenTheVoiceEventDescribesANotifyEventWithARecordFinishedType()
         {
-            _voiceClient.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _voiceClient.SinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",
@@ -293,7 +293,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""recording_available"" type")]
         public void ThenTheVoiceEventNotifyDescribesAEventWithARecordingAvailableType()
         {
-            _voiceClient.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _voiceClient.SinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",
@@ -322,7 +322,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""transcription_available"" type")]
         public void ThenTheVoiceEventDescribesANotifyEventWithATranscriptionAvailableType()
         {
-            _voiceClient.ParseEvent(_rawEventTransactionContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _voiceClient.SinchEvents.ParseEvent(_rawEventTransactionContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",

--- a/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
@@ -1,7 +1,10 @@
 using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Reqnroll;
+using Sinch.Auth;
 using Sinch.Voice;
 using Sinch.Voice.Callouts.Callout;
 using Sinch.Voice.Calls;
@@ -14,7 +17,7 @@ namespace Sinch.Tests.Features.Voice
     public class SinchEvents
     {
         private readonly HttpClient _httpClient = new HttpClient();
-        private ISinchVoiceClient _voiceClient;
+        private IVoiceSinchEvents _sinchEvents;
         private HttpResponseMessage _pieReturnResponse;
         private string _rawPieSequenceContent;
         private HttpResponseMessage _pieSequenceResponse;
@@ -33,24 +36,13 @@ namespace Sinch.Tests.Features.Voice
         [Given(@"the Voice Webhooks handler is available")]
         public void GivenTheVoiceSinchEventsHandlerIsAvailable()
         {
-            _voiceClient = new SinchClient(
-                new SinchClientConfiguration
+            _sinchEvents = new VoiceSinchEvents(
+                new JsonSerializerOptions(JsonSerializerDefaults.Web)
                 {
-                    SinchOptions = new SinchOptions
-                    {
-                        ApiUrlOverrides = new ApiUrlOverrides()
-                        {
-                            VoiceUrl = "http://localhost:3019",
-                            VoiceApplicationManagementUrl = "http://localhost:3020"
-                        }
-                    },
-                    VoiceConfiguration = new SinchVoiceConfiguration()
-                    {
-                        AppKey = "appKey",
-                        AppSecret = "YXBwU2VjcmV0"
-                    }
-                }
-            ).Voice;
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+                },
+                new ApplicationSignedAuth("appKey", "YXBwU2VjcmV0"));
         }
 
         [When(@"I send a request to trigger a ""PIE"" event with a ""return"" type")]
@@ -63,7 +55,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventWithATypeContainsAValidAuthorization()
         {
             _rawPieSequenceContent = await _pieReturnResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _pieReturnResponse.GetAllHeaders(),
                 _rawPieSequenceContent).Should().BeTrue();
         }
@@ -71,7 +63,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""PIE"" event with a ""return"" type")]
         public void ThenTheVoiceEventDescribesAEventWithAType()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
+            _sinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
                 new PromptInputEvent
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000013",
@@ -99,7 +91,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventWithAPieTypeSequenceContainsAValidAuthorization()
         {
             _rawPieSequenceContent = await _pieSequenceResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _pieSequenceResponse.GetAllHeaders(),
                 _rawPieSequenceContent).Should().BeTrue();
         }
@@ -107,7 +99,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""PIE"" event with a ""sequence"" type")]
         public void ThenTheVoiceEventDescribesAPieEventWithASequenceType()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
+            _sinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
                 new PromptInputEvent
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000023",
@@ -135,7 +127,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventDiceContainsAValidAuthorization()
         {
             _rawDiceContent = await _diceResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _diceResponse.GetAllHeaders(),
                 _rawDiceContent).Should().BeTrue();
         }
@@ -143,7 +135,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""DICE"" event")]
         public void ThenTheVoiceEventDescribesAEvent()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawDiceContent).Should().BeEquivalentTo(new DisconnectedCallEvent
+            _sinchEvents.ParseEvent(_rawDiceContent).Should().BeEquivalentTo(new DisconnectedCallEvent
             {
                 CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000033",
                 Timestamp = Helpers.ParseUtc("2024-06-06T16:59:42Z"),
@@ -182,7 +174,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventContainsAValidAuthorization()
         {
             _rawAceContent = await _aceResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _aceResponse.GetAllHeaders(),
                 _rawAceContent).Should().BeTrue();
         }
@@ -190,7 +182,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""ACE"" event")]
         public void ThenTheVoiceEventDescribesAceEvent()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawAceContent).Should().BeEquivalentTo(new AnsweredCallEvent
+            _sinchEvents.ParseEvent(_rawAceContent).Should().BeEquivalentTo(new AnsweredCallEvent
             {
                 CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000043",
                 CallResourceUrl = null,
@@ -212,7 +204,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheIceEventContainsAValidAuthorization()
         {
             _rawIceContent = await _iceResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _iceResponse.GetAllHeaders(),
                 _rawIceContent).Should().BeTrue();
         }
@@ -220,7 +212,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""ICE"" event")]
         public void ThenTheVoiceEventDescribesAIceEvent()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawIceContent).As<IncomingCallEvent>().Should().BeEquivalentTo(
+            _sinchEvents.ParseEvent(_rawIceContent).As<IncomingCallEvent>().Should().BeEquivalentTo(
                 new IncomingCallEvent()
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000053",
@@ -257,7 +249,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheRecordingFinishedEventContainsAValidAuthorization()
         {
             _rawEventRecordAvailableContent = await _eventRecordingFinishedResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventRecordingFinishedResponse.GetAllHeaders(),
                 _rawEventRecordAvailableContent).Should().BeTrue();
         }
@@ -265,7 +257,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""recording_finished"" type")]
         public void ThenTheVoiceEventDescribesANotifyEventWithARecordFinishedType()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _sinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",
@@ -285,7 +277,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheRecordingAvailableEventContainsAValidAuthorization()
         {
             _rawEventRecordAvailableContent = await _eventRecordingAvailableResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventRecordingAvailableResponse.GetAllHeaders(),
                 _rawEventRecordAvailableContent).Should().BeTrue();
         }
@@ -293,7 +285,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""recording_available"" type")]
         public void ThenTheVoiceEventNotifyDescribesAEventWithARecordingAvailableType()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _sinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",
@@ -314,7 +306,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheTranscriptionAvailableEventContainsAValidAuthorization()
         {
             _rawEventTransactionContent = await _eventTranscriptionAvailableResponse.Content.ReadAsStringAsync();
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventTranscriptionAvailableResponse.GetAllHeaders(),
                 _rawEventTransactionContent).Should().BeTrue();
         }
@@ -322,7 +314,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""transcription_available"" type")]
         public void ThenTheVoiceEventDescribesANotifyEventWithATranscriptionAvailableType()
         {
-            _voiceClient.SinchEvents.ParseEvent(_rawEventTransactionContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _sinchEvents.ParseEvent(_rawEventTransactionContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",

--- a/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
@@ -16,8 +16,8 @@ namespace Sinch.Tests.Features.Voice
     [Binding]
     public class SinchEvents
     {
-        private readonly HttpClient _httpClient = new HttpClient();
-        private IVoiceSinchEvents _sinchEvents;
+        private readonly HttpClient _httpClient = new();
+        private IVoiceSinchEvents _voiceSinchEvents;
         private HttpResponseMessage _pieReturnResponse;
         private string _rawPieSequenceContent;
         private HttpResponseMessage _pieSequenceResponse;
@@ -36,12 +36,8 @@ namespace Sinch.Tests.Features.Voice
         [Given(@"the Voice Webhooks handler is available")]
         public void GivenTheVoiceSinchEventsHandlerIsAvailable()
         {
-            _sinchEvents = new VoiceSinchEvents(
-                new JsonSerializerOptions(JsonSerializerDefaults.Web)
-                {
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-                },
+            _voiceSinchEvents = new VoiceSinchEvents(
+                new JsonSerializerOptions(JsonSerializerDefaults.Web),
                 new ApplicationSignedAuth("appKey", "YXBwU2VjcmV0"));
         }
 
@@ -55,7 +51,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventWithATypeContainsAValidAuthorization()
         {
             _rawPieSequenceContent = await _pieReturnResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _pieReturnResponse.GetAllHeaders(),
                 _rawPieSequenceContent).Should().BeTrue();
         }
@@ -63,7 +59,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""PIE"" event with a ""return"" type")]
         public void ThenTheVoiceEventDescribesAEventWithAType()
         {
-            _sinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
+            _voiceSinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
                 new PromptInputEvent
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000013",
@@ -91,7 +87,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventWithAPieTypeSequenceContainsAValidAuthorization()
         {
             _rawPieSequenceContent = await _pieSequenceResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _pieSequenceResponse.GetAllHeaders(),
                 _rawPieSequenceContent).Should().BeTrue();
         }
@@ -99,7 +95,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""PIE"" event with a ""sequence"" type")]
         public void ThenTheVoiceEventDescribesAPieEventWithASequenceType()
         {
-            _sinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
+            _voiceSinchEvents.ParseEvent(_rawPieSequenceContent).As<PromptInputEvent>().Should().BeEquivalentTo(
                 new PromptInputEvent
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000023",
@@ -127,7 +123,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventDiceContainsAValidAuthorization()
         {
             _rawDiceContent = await _diceResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _diceResponse.GetAllHeaders(),
                 _rawDiceContent).Should().BeTrue();
         }
@@ -135,7 +131,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""DICE"" event")]
         public void ThenTheVoiceEventDescribesAEvent()
         {
-            _sinchEvents.ParseEvent(_rawDiceContent).Should().BeEquivalentTo(new DisconnectedCallEvent
+            _voiceSinchEvents.ParseEvent(_rawDiceContent).Should().BeEquivalentTo(new DisconnectedCallEvent
             {
                 CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000033",
                 Timestamp = Helpers.ParseUtc("2024-06-06T16:59:42Z"),
@@ -174,7 +170,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventContainsAValidAuthorization()
         {
             _rawAceContent = await _aceResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _aceResponse.GetAllHeaders(),
                 _rawAceContent).Should().BeTrue();
         }
@@ -182,7 +178,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""ACE"" event")]
         public void ThenTheVoiceEventDescribesAceEvent()
         {
-            _sinchEvents.ParseEvent(_rawAceContent).Should().BeEquivalentTo(new AnsweredCallEvent
+            _voiceSinchEvents.ParseEvent(_rawAceContent).Should().BeEquivalentTo(new AnsweredCallEvent
             {
                 CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000043",
                 CallResourceUrl = null,
@@ -204,7 +200,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheIceEventContainsAValidAuthorization()
         {
             _rawIceContent = await _iceResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _iceResponse.GetAllHeaders(),
                 _rawIceContent).Should().BeTrue();
         }
@@ -212,7 +208,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""ICE"" event")]
         public void ThenTheVoiceEventDescribesAIceEvent()
         {
-            _sinchEvents.ParseEvent(_rawIceContent).As<IncomingCallEvent>().Should().BeEquivalentTo(
+            _voiceSinchEvents.ParseEvent(_rawIceContent).As<IncomingCallEvent>().Should().BeEquivalentTo(
                 new IncomingCallEvent()
                 {
                     CallId = "1ce0ffee-ca11-ca11-ca11-abcdef000053",
@@ -249,7 +245,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheRecordingFinishedEventContainsAValidAuthorization()
         {
             _rawEventRecordAvailableContent = await _eventRecordingFinishedResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventRecordingFinishedResponse.GetAllHeaders(),
                 _rawEventRecordAvailableContent).Should().BeTrue();
         }
@@ -257,7 +253,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""recording_finished"" type")]
         public void ThenTheVoiceEventDescribesANotifyEventWithARecordFinishedType()
         {
-            _sinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _voiceSinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",
@@ -277,7 +273,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheRecordingAvailableEventContainsAValidAuthorization()
         {
             _rawEventRecordAvailableContent = await _eventRecordingAvailableResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventRecordingAvailableResponse.GetAllHeaders(),
                 _rawEventRecordAvailableContent).Should().BeTrue();
         }
@@ -285,7 +281,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""recording_available"" type")]
         public void ThenTheVoiceEventNotifyDescribesAEventWithARecordingAvailableType()
         {
-            _sinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _voiceSinchEvents.ParseEvent(_rawEventRecordAvailableContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",
@@ -306,7 +302,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheTranscriptionAvailableEventContainsAValidAuthorization()
         {
             _rawEventTransactionContent = await _eventTranscriptionAvailableResponse.Content.ReadAsStringAsync();
-            _sinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventTranscriptionAvailableResponse.GetAllHeaders(),
                 _rawEventTransactionContent).Should().BeTrue();
         }
@@ -314,7 +310,7 @@ namespace Sinch.Tests.Features.Voice
         [Then(@"the Voice event describes a ""notify"" event with a ""transcription_available"" type")]
         public void ThenTheVoiceEventDescribesANotifyEventWithATranscriptionAvailableType()
         {
-            _sinchEvents.ParseEvent(_rawEventTransactionContent).As<NotificationEvent>().Should().BeEquivalentTo(
+            _voiceSinchEvents.ParseEvent(_rawEventTransactionContent).As<NotificationEvent>().Should().BeEquivalentTo(
                 new NotificationEvent()
                 {
                     CallId = "33dd8e62-0ac6-4e0c-a89f-36d121f861f9",

--- a/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
+++ b/tests/Sinch.Tests.Features/Voice/SinchEvents.cs
@@ -63,7 +63,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventWithATypeContainsAValidAuthorization()
         {
             _rawPieSequenceContent = await _pieReturnResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _pieReturnResponse.GetAllHeaders(),
                 _rawPieSequenceContent).Should().BeTrue();
         }
@@ -99,7 +99,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventWithAPieTypeSequenceContainsAValidAuthorization()
         {
             _rawPieSequenceContent = await _pieSequenceResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _pieSequenceResponse.GetAllHeaders(),
                 _rawPieSequenceContent).Should().BeTrue();
         }
@@ -135,7 +135,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventDiceContainsAValidAuthorization()
         {
             _rawDiceContent = await _diceResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _diceResponse.GetAllHeaders(),
                 _rawDiceContent).Should().BeTrue();
         }
@@ -182,7 +182,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheEventContainsAValidAuthorization()
         {
             _rawAceContent = await _aceResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _aceResponse.GetAllHeaders(),
                 _rawAceContent).Should().BeTrue();
         }
@@ -212,7 +212,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheIceEventContainsAValidAuthorization()
         {
             _rawIceContent = await _iceResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _iceResponse.GetAllHeaders(),
                 _rawIceContent).Should().BeTrue();
         }
@@ -257,7 +257,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheRecordingFinishedEventContainsAValidAuthorization()
         {
             _rawEventRecordAvailableContent = await _eventRecordingFinishedResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventRecordingFinishedResponse.GetAllHeaders(),
                 _rawEventRecordAvailableContent).Should().BeTrue();
         }
@@ -285,7 +285,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheRecordingAvailableEventContainsAValidAuthorization()
         {
             _rawEventRecordAvailableContent = await _eventRecordingAvailableResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventRecordingAvailableResponse.GetAllHeaders(),
                 _rawEventRecordAvailableContent).Should().BeTrue();
         }
@@ -314,7 +314,7 @@ namespace Sinch.Tests.Features.Voice
         public async Task ThenTheHeaderOfTheTranscriptionAvailableEventContainsAValidAuthorization()
         {
             _rawEventTransactionContent = await _eventTranscriptionAvailableResponse.Content.ReadAsStringAsync();
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/webhooks/voice",
                 _eventTranscriptionAvailableResponse.GetAllHeaders(),
                 _rawEventTransactionContent).Should().BeTrue();
         }

--- a/tests/Sinch.Tests/Conversation/ConversationTestBase.cs
+++ b/tests/Sinch.Tests/Conversation/ConversationTestBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Text.Json;
 using Sinch.Conversation;
-using Sinch.Conversation.SinchEvents;
 using Sinch.Core;
 
 namespace Sinch.Tests.Conversation

--- a/tests/Sinch.Tests/Conversation/ConversationTestBase.cs
+++ b/tests/Sinch.Tests/Conversation/ConversationTestBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text.Json;
 using Sinch.Conversation;
+using Sinch.Conversation.SinchEvents;
 using Sinch.Core;
 
 namespace Sinch.Tests.Conversation

--- a/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
+++ b/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
@@ -17,7 +17,7 @@ namespace Sinch.Tests.Conversation
 {
     public class EventDestinationsTests : ConversationTestBase
     {
-        private readonly ConversationSinchEvents _sinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
+        private readonly ConversationSinchEvents _conversationSinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
         
         [Fact]
         public void DeserializeCapabilityEvent()
@@ -25,7 +25,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<CapabilityEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<CapabilityEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<CapabilityEvent>();
@@ -66,7 +66,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ChannelEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<ChannelEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<ChannelEvent>();
             AssertEvent(resultParse);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ChannelEvent>();
@@ -109,7 +109,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactCreateEvent.json");
 
-            var parseResult = _sinchEvents.ParseEvent(json).As<ContactCreateEvent>();
+            var parseResult = _conversationSinchEvents.ParseEvent(json).As<ContactCreateEvent>();
             AssertEvent(parseResult);
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactCreateEvent>();
             AssertEvent(result);
@@ -166,7 +166,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactDeleteEvent.json");
 
-            var parseResult = _sinchEvents.ParseEvent(json).As<ContactDeleteEvent>();
+            var parseResult = _conversationSinchEvents.ParseEvent(json).As<ContactDeleteEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactDeleteEvent>();
@@ -225,7 +225,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactIdentitiesDuplicationEvent.json");
 
-            var parseResult = _sinchEvents.ParseEvent(json).As<ContactIdentitiesDuplicationEvent>();
+            var parseResult = _conversationSinchEvents.ParseEvent(json).As<ContactIdentitiesDuplicationEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactIdentitiesDuplicationEvent>();
@@ -266,7 +266,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ContactMergeEvent.json");
 
-            var parseResult = _sinchEvents.ParseEvent(json).As<ContactMergeEvent>();
+            var parseResult = _conversationSinchEvents.ParseEvent(json).As<ContactMergeEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactMergeEvent>();
@@ -333,7 +333,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ContactUpdateEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<ContactUpdateEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<ContactUpdateEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ContactUpdateEvent>();
@@ -385,7 +385,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationDeleteEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<ConversationDeleteEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<ConversationDeleteEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationDeleteEvent>();
@@ -432,7 +432,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationStartEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<ConversationStartEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<ConversationStartEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationStartEvent>();
@@ -480,7 +480,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationStopEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<ConversationStopEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<ConversationStopEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationStopEvent>();
@@ -528,7 +528,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/EventDeliveryReportEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<DeliveryEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<DeliveryEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<DeliveryEvent>();
@@ -574,7 +574,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageDeliveryReceiptEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<MessageDeliveryReceiptEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<MessageDeliveryReceiptEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageDeliveryReceiptEvent>();
@@ -622,7 +622,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/InboundContactEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<InboundEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<InboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<InboundEvent>();
@@ -668,7 +668,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/InboundContactMessageEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<InboundEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<InboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<InboundEvent>();
@@ -718,7 +718,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageInboundEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<MessageInboundEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<MessageInboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageInboundEvent>();
@@ -765,7 +765,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageSubmitEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<MessageSubmitEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<MessageSubmitEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageSubmitEvent>();
@@ -906,7 +906,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/MessageInboundSmartConversationRedactionEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json)
+            var resultParse = _conversationSinchEvents.ParseEvent(json)
                 .As<MessageInboundSmartConversationRedactionEvent>();
             AssertEvent(resultParse);
 
@@ -960,7 +960,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/SmartConversationsEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<SmartConversationsEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<SmartConversationsEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<SmartConversationsEvent>();
@@ -1088,7 +1088,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/UnsupportedCallbackEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<UnsupportedCallbackEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<UnsupportedCallbackEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<UnsupportedCallbackEvent>();
@@ -1128,7 +1128,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/OptInEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<OptInEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<OptInEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<OptInEvent>();
@@ -1165,7 +1165,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/OptOutEvent.json");
 
-            var resultParse = _sinchEvents.ParseEvent(json).As<OptOutEvent>();
+            var resultParse = _conversationSinchEvents.ParseEvent(json).As<OptOutEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<OptOutEvent>();
@@ -1251,9 +1251,9 @@ namespace Sinch.Tests.Conversation
         [Fact]
         public async Task DeserializeEventDestinationWithoutProvidingSinchUnifiedCredentials()
         {
-            var sinchEvents = new ConversationSinchEvents(SinchConversationClient.JsonSerializerOptionsInner);
+            var conversationSinchEvents = new ConversationSinchEvents(SinchConversationClient.JsonSerializerOptionsInner);
             var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
-            var actual = sinchEvents.ParseEvent(json).As<CapabilityEvent>();
+            var actual = conversationSinchEvents.ParseEvent(json).As<CapabilityEvent>();
 
             actual.Should().BeEquivalentTo(new CapabilityEvent()
             {
@@ -1332,7 +1332,7 @@ namespace Sinch.Tests.Conversation
                 }
             }";
 
-            Action act = () => _sinchEvents.ParseEvent(json);
+            Action act = () => _conversationSinchEvents.ParseEvent(json);
 
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("Deserialization of conversation Sinch event failed");

--- a/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
+++ b/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
@@ -17,13 +17,15 @@ namespace Sinch.Tests.Conversation
 {
     public class EventDestinationsTests : ConversationTestBase
     {
+        private readonly ConversationSinchEvents _sinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
+        
         [Fact]
         public void DeserializeCapabilityEvent()
         {
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<CapabilityEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<CapabilityEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<CapabilityEvent>();
@@ -64,7 +66,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ChannelEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ChannelEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<ChannelEvent>();
             AssertEvent(resultParse);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ChannelEvent>();
@@ -107,7 +109,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactCreateEvent.json");
 
-            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactCreateEvent>();
+            var parseResult = _sinchEvents.ParseEvent(json).As<ContactCreateEvent>();
             AssertEvent(parseResult);
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactCreateEvent>();
             AssertEvent(result);
@@ -164,7 +166,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactDeleteEvent.json");
 
-            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactDeleteEvent>();
+            var parseResult = _sinchEvents.ParseEvent(json).As<ContactDeleteEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactDeleteEvent>();
@@ -223,7 +225,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactIdentitiesDuplicationEvent.json");
 
-            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactIdentitiesDuplicationEvent>();
+            var parseResult = _sinchEvents.ParseEvent(json).As<ContactIdentitiesDuplicationEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactIdentitiesDuplicationEvent>();
@@ -264,7 +266,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ContactMergeEvent.json");
 
-            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactMergeEvent>();
+            var parseResult = _sinchEvents.ParseEvent(json).As<ContactMergeEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactMergeEvent>();
@@ -331,7 +333,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ContactUpdateEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ContactUpdateEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<ContactUpdateEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ContactUpdateEvent>();
@@ -383,7 +385,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationDeleteEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ConversationDeleteEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<ConversationDeleteEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationDeleteEvent>();
@@ -430,7 +432,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationStartEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ConversationStartEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<ConversationStartEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationStartEvent>();
@@ -478,7 +480,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationStopEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ConversationStopEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<ConversationStopEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationStopEvent>();
@@ -526,7 +528,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/EventDeliveryReportEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<DeliveryEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<DeliveryEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<DeliveryEvent>();
@@ -572,7 +574,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageDeliveryReceiptEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<MessageDeliveryReceiptEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<MessageDeliveryReceiptEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageDeliveryReceiptEvent>();
@@ -620,7 +622,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/InboundContactEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<InboundEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<InboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<InboundEvent>();
@@ -666,7 +668,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/InboundContactMessageEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<InboundEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<InboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<InboundEvent>();
@@ -716,7 +718,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageInboundEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<MessageInboundEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<MessageInboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageInboundEvent>();
@@ -763,7 +765,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageSubmitEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<MessageSubmitEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<MessageSubmitEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageSubmitEvent>();
@@ -904,7 +906,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/MessageInboundSmartConversationRedactionEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json)
+            var resultParse = _sinchEvents.ParseEvent(json)
                 .As<MessageInboundSmartConversationRedactionEvent>();
             AssertEvent(resultParse);
 
@@ -958,7 +960,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/SmartConversationsEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<SmartConversationsEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<SmartConversationsEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<SmartConversationsEvent>();
@@ -1086,7 +1088,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/UnsupportedCallbackEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<UnsupportedCallbackEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<UnsupportedCallbackEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<UnsupportedCallbackEvent>();
@@ -1126,7 +1128,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/OptInEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<OptInEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<OptInEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<OptInEvent>();
@@ -1163,7 +1165,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/OptOutEvent.json");
 
-            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<OptOutEvent>();
+            var resultParse = _sinchEvents.ParseEvent(json).As<OptOutEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<OptOutEvent>();
@@ -1249,18 +1251,9 @@ namespace Sinch.Tests.Conversation
         [Fact]
         public async Task DeserializeEventDestinationWithoutProvidingSinchUnifiedCredentials()
         {
-            var sinchClient = new SinchClient(new SinchClientConfiguration()
-            {
-                // TODO! It will removed with this ticket: https://sinchenterprise.atlassian.net/browse/DEVEXP-1311
-                ConversationConfiguration = new SinchConversationConfiguration()
-                {
-                    Region = ConversationRegion.Us
-                }
-            });
-
-            string json =
-                Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
-            var actual = sinchClient.Conversation.SinchEvents.ParseEvent(json).As<CapabilityEvent>();
+            var sinchEvents = new ConversationSinchEvents(SinchConversationClient.JsonSerializerOptionsInner);
+            var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
+            var actual = sinchEvents.ParseEvent(json).As<CapabilityEvent>();
 
             actual.Should().BeEquivalentTo(new CapabilityEvent()
             {
@@ -1287,6 +1280,13 @@ namespace Sinch.Tests.Conversation
                 }
             });
 
+            var sinchClient = new SinchClient(new SinchClientConfiguration()
+            {
+                ConversationConfiguration = new SinchConversationConfiguration()
+                {
+                    Region = ConversationRegion.Us
+                }
+            });
             // other conversation endpoints should throw an error
             var op = () => sinchClient.Conversation.Messages.Get("1");
             await op.Should()
@@ -1332,7 +1332,7 @@ namespace Sinch.Tests.Conversation
                 }
             }";
 
-            Action act = () => Conversation.SinchEvents.ParseEvent(json);
+            Action act = () => _sinchEvents.ParseEvent(json);
 
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("Deserialization of conversation Sinch event failed");

--- a/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
+++ b/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
@@ -23,7 +23,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<CapabilityEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<CapabilityEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<CapabilityEvent>();
@@ -64,7 +64,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ChannelEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<ChannelEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ChannelEvent>();
             AssertEvent(resultParse);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ChannelEvent>();
@@ -107,7 +107,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactCreateEvent.json");
 
-            var parseResult = Conversation.EventDestinations.ParseEvent(json).As<ContactCreateEvent>();
+            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactCreateEvent>();
             AssertEvent(parseResult);
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactCreateEvent>();
             AssertEvent(result);
@@ -164,7 +164,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactDeleteEvent.json");
 
-            var parseResult = Conversation.EventDestinations.ParseEvent(json).As<ContactDeleteEvent>();
+            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactDeleteEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactDeleteEvent>();
@@ -223,7 +223,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/ContactIdentitiesDuplicationEvent.json");
 
-            var parseResult = Conversation.EventDestinations.ParseEvent(json).As<ContactIdentitiesDuplicationEvent>();
+            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactIdentitiesDuplicationEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactIdentitiesDuplicationEvent>();
@@ -264,7 +264,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ContactMergeEvent.json");
 
-            var parseResult = Conversation.EventDestinations.ParseEvent(json).As<ContactMergeEvent>();
+            var parseResult = Conversation.SinchEvents.ParseEvent(json).As<ContactMergeEvent>();
             AssertEvent(parseResult);
 
             var result = Deserialize<IConversationSinchEvent>(json).As<ContactMergeEvent>();
@@ -331,7 +331,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ContactUpdateEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<ContactUpdateEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ContactUpdateEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ContactUpdateEvent>();
@@ -383,7 +383,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationDeleteEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<ConversationDeleteEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ConversationDeleteEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationDeleteEvent>();
@@ -430,7 +430,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationStartEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<ConversationStartEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ConversationStartEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationStartEvent>();
@@ -478,7 +478,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/ConversationStopEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<ConversationStopEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<ConversationStopEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<ConversationStopEvent>();
@@ -526,7 +526,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/EventDeliveryReportEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<DeliveryEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<DeliveryEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<DeliveryEvent>();
@@ -572,7 +572,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageDeliveryReceiptEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<MessageDeliveryReceiptEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<MessageDeliveryReceiptEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageDeliveryReceiptEvent>();
@@ -620,7 +620,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/InboundContactEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<InboundEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<InboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<InboundEvent>();
@@ -666,7 +666,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/InboundContactMessageEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<InboundEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<InboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<InboundEvent>();
@@ -716,7 +716,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageInboundEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<MessageInboundEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<MessageInboundEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageInboundEvent>();
@@ -763,7 +763,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/MessageSubmitEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<MessageSubmitEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<MessageSubmitEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<MessageSubmitEvent>();
@@ -904,7 +904,7 @@ namespace Sinch.Tests.Conversation
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/MessageInboundSmartConversationRedactionEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json)
+            var resultParse = Conversation.SinchEvents.ParseEvent(json)
                 .As<MessageInboundSmartConversationRedactionEvent>();
             AssertEvent(resultParse);
 
@@ -958,7 +958,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/SmartConversationsEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<SmartConversationsEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<SmartConversationsEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<SmartConversationsEvent>();
@@ -1086,7 +1086,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/UnsupportedCallbackEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<UnsupportedCallbackEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<UnsupportedCallbackEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<UnsupportedCallbackEvent>();
@@ -1126,7 +1126,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/OptInEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<OptInEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<OptInEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<OptInEvent>();
@@ -1163,7 +1163,7 @@ namespace Sinch.Tests.Conversation
         {
             string json = Helpers.LoadResources("Conversation/SinchEvents/OptOutEvent.json");
 
-            var resultParse = Conversation.EventDestinations.ParseEvent(json).As<OptOutEvent>();
+            var resultParse = Conversation.SinchEvents.ParseEvent(json).As<OptOutEvent>();
             AssertEvent(resultParse);
 
             var resultDeserialize = Deserialize<IConversationSinchEvent>(json).As<OptOutEvent>();
@@ -1260,7 +1260,7 @@ namespace Sinch.Tests.Conversation
 
             string json =
                 Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
-            var actual = sinchClient.Conversation.EventDestinations.ParseEvent(json).As<CapabilityEvent>();
+            var actual = sinchClient.Conversation.SinchEvents.ParseEvent(json).As<CapabilityEvent>();
 
             actual.Should().BeEquivalentTo(new CapabilityEvent()
             {
@@ -1332,7 +1332,7 @@ namespace Sinch.Tests.Conversation
                 }
             }";
 
-            Action act = () => Conversation.EventDestinations.ParseEvent(json);
+            Action act = () => Conversation.SinchEvents.ParseEvent(json);
 
             act.Should().Throw<InvalidOperationException>()
                 .WithMessage("Deserialization of conversation Sinch event failed");
@@ -1346,3 +1346,5 @@ namespace Sinch.Tests.Conversation
         }
     }
 }
+
+

--- a/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
+++ b/tests/Sinch.Tests/Conversation/EventDestinationsTests.cs
@@ -18,7 +18,7 @@ namespace Sinch.Tests.Conversation
     public class EventDestinationsTests : ConversationTestBase
     {
         private readonly ConversationSinchEvents _conversationSinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
-        
+
         [Fact]
         public void DeserializeCapabilityEvent()
         {

--- a/tests/Sinch.Tests/Conversation/SinchEvents/HmacAuthenticationValidationTests.cs
+++ b/tests/Sinch.Tests/Conversation/SinchEvents/HmacAuthenticationValidationTests.cs
@@ -22,14 +22,14 @@ namespace Sinch.Tests.Conversation.SinchEvents
         private const string ValidSignature = "ehhrg9MUuhpJUCo2drsI3zoqWViaojp8d6RahfBY3cg=";
 
         [Fact]
-        public void ValidateAuthenticationHeader_WithSingleValueHeaders_ReturnsTrue()
+        public void ValidateAuthenticationHeader_WithMultiValueHeaders_ReturnsTrue()
         {
-            IDictionary<string, string> headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                [TimestampHeader] = ValidTimestamp,
-                [NonceHeader] = ValidNonce,
-                [AlgorithmHeader] = ValidAlgorithm,
-                [SignatureHeader] = ValidSignature
+                [TimestampHeader] = [ValidTimestamp],
+                [NonceHeader] = [ValidNonce],
+                [AlgorithmHeader] = [ValidAlgorithm],
+                [SignatureHeader] = [ValidSignature]
             };
 
             var result = HmacAuthenticationValidation.ValidateAuthenticationHeader(ValidSecret, headers, ValidJsonPayload);
@@ -56,12 +56,12 @@ namespace Sinch.Tests.Conversation.SinchEvents
         [Fact]
         public void ValidateAuthenticationHeader_WithInvalidSignature_ReturnsFalse()
         {
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                [TimestampHeader] = ValidTimestamp,
-                [NonceHeader] = ValidNonce,
-                [AlgorithmHeader] = ValidAlgorithm,
-                [SignatureHeader] = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+                [TimestampHeader] = [ValidTimestamp],
+                [NonceHeader] = [ValidNonce],
+                [AlgorithmHeader] = [ValidAlgorithm],
+                [SignatureHeader] = ["AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="]
             };
 
             var result = HmacAuthenticationValidation.ValidateAuthenticationHeader(ValidSecret, headers, ValidJsonPayload);
@@ -74,12 +74,12 @@ namespace Sinch.Tests.Conversation.SinchEvents
         {
             const string unsupportedAlgorithm = "HmacSHA512";
 
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                [TimestampHeader] = ValidTimestamp,
-                [NonceHeader] = ValidNonce,
-                [AlgorithmHeader] = unsupportedAlgorithm,
-                [SignatureHeader] = ValidSignature
+                [TimestampHeader] = [ValidTimestamp],
+                [NonceHeader] = [ValidNonce],
+                [AlgorithmHeader] = [unsupportedAlgorithm],
+                [SignatureHeader] = [ValidSignature]
             };
 
             Action act = () => HmacAuthenticationValidation.ValidateAuthenticationHeader(ValidSecret, headers, ValidJsonPayload);
@@ -94,12 +94,12 @@ namespace Sinch.Tests.Conversation.SinchEvents
         [InlineData(AlgorithmHeader)]
         public void ValidateAuthenticationHeader_MissingHeader_ReturnsFalse(string missingHeader)
         {
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                [TimestampHeader] = ValidTimestamp,
-                [NonceHeader] = ValidNonce,
-                [AlgorithmHeader] = ValidAlgorithm,
-                [SignatureHeader] = ValidSignature
+                [TimestampHeader] = [ValidTimestamp],
+                [NonceHeader] = [ValidNonce],
+                [AlgorithmHeader] = [ValidAlgorithm],
+                [SignatureHeader] = [ValidSignature]
             };
 
             headers.Remove(missingHeader);
@@ -114,12 +114,12 @@ namespace Sinch.Tests.Conversation.SinchEvents
         {
             var emptySecret = string.Empty;
 
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                [TimestampHeader] = ValidTimestamp,
-                [NonceHeader] = ValidNonce,
-                [AlgorithmHeader] = ValidAlgorithm,
-                [SignatureHeader] = ValidSignature
+                [TimestampHeader] = [ValidTimestamp],
+                [NonceHeader] = [ValidNonce],
+                [AlgorithmHeader] = [ValidAlgorithm],
+                [SignatureHeader] = [ValidSignature]
             };
 
             var result = HmacAuthenticationValidation.ValidateAuthenticationHeader(emptySecret, headers, ValidJsonPayload);

--- a/tests/Sinch.Tests/Conversation/SinchEvents/HmacAuthenticationValidationTests.cs
+++ b/tests/Sinch.Tests/Conversation/SinchEvents/HmacAuthenticationValidationTests.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
-using Sinch.Conversation.EventDestinations;
+using Sinch.Conversation.SinchEvents;
 using Xunit;
 
-namespace Sinch.Tests.Conversation.EventDestinations
+namespace Sinch.Tests.Conversation.SinchEvents
 {
     public class HmacAuthenticationValidationTests
     {

--- a/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
@@ -6,7 +6,7 @@ using FluentAssertions;
 using Sinch.Conversation.SinchEvents;
 using Xunit;
 
-namespace Sinch.Tests.Conversation.EventDestinations
+namespace Sinch.Tests.Conversation.SinchEvents
 {
     public class SinchEventsTests : ConversationTestBase
     {
@@ -21,7 +21,7 @@ namespace Sinch.Tests.Conversation.EventDestinations
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");
 
-            var isValid = Conversation.EventDestinations.ValidateAuthenticationHeader(new Dictionary<string, string>()
+            var isValid = Conversation.SinchEvents.ValidateAuthenticationHeader(new Dictionary<string, string>()
             {
                 { NonceHeader, "01FJA8B4A7BM43YGWSG9GBV067" },
                 { TimestampHeader, "1634579353" },
@@ -37,7 +37,7 @@ namespace Sinch.Tests.Conversation.EventDestinations
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");
 
-            var isValid = Conversation.EventDestinations.ValidateAuthenticationHeader(new Dictionary<string, IEnumerable<string>>()
+            var isValid = Conversation.SinchEvents.ValidateAuthenticationHeader(new Dictionary<string, IEnumerable<string>>()
             {
                 { NonceHeader, ["01FJA8B4A7BM43YGWSG9GBV067"] },
                 { TimestampHeader, ["1634579353"] },
@@ -53,7 +53,7 @@ namespace Sinch.Tests.Conversation.EventDestinations
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
 
-            var result = Conversation.EventDestinations.ParseEvent(json);
+            var result = Conversation.SinchEvents.ParseEvent(json);
 
             result.Should().BeOfType<CapabilityEvent>();
             result.As<CapabilityEvent>().CapabilityNotification.Should().NotBeNull();
@@ -65,11 +65,12 @@ namespace Sinch.Tests.Conversation.EventDestinations
             var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
             await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
-            var result = await Conversation.EventDestinations.ParseEventAsync(stream);
+            var result = await Conversation.SinchEvents.ParseEventAsync(stream);
 
             result.Should().BeOfType<CapabilityEvent>();
             result.As<CapabilityEvent>().CapabilityNotification.Should().NotBeNull();
         }
     }
 }
+
 

--- a/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
@@ -17,14 +17,14 @@ namespace Sinch.Tests.Conversation.SinchEvents
         private const string AlgorithmHeader = "x-sinch-webhook-signature-algorithm";
         private const string SignatureHeader = "x-sinch-webhook-signature";
         
-        private readonly ConversationSinchEvents _sinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
+        private readonly ConversationSinchEvents _conversationSinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
 
         [Fact]
         public void ValidateAuthenticationHeader_WithSingleValueHeaders_ReturnsTrue()
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");
 
-            var isValid = _sinchEvents.ValidateAuthenticationHeader(new Dictionary<string, string>()
+            var isValid = _conversationSinchEvents.ValidateAuthenticationHeader(new Dictionary<string, string>()
             {
                 { NonceHeader, "01FJA8B4A7BM43YGWSG9GBV067" },
                 { TimestampHeader, "1634579353" },
@@ -40,7 +40,7 @@ namespace Sinch.Tests.Conversation.SinchEvents
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");
 
-            var isValid = _sinchEvents.ValidateAuthenticationHeader(new Dictionary<string, IEnumerable<string>>()
+            var isValid = _conversationSinchEvents.ValidateAuthenticationHeader(new Dictionary<string, IEnumerable<string>>()
             {
                 { NonceHeader, ["01FJA8B4A7BM43YGWSG9GBV067"] },
                 { TimestampHeader, ["1634579353"] },
@@ -56,7 +56,7 @@ namespace Sinch.Tests.Conversation.SinchEvents
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
 
-            var result = _sinchEvents.ParseEvent(json);
+            var result = _conversationSinchEvents.ParseEvent(json);
 
             result.Should().BeOfType<CapabilityEvent>();
             result.As<CapabilityEvent>().CapabilityNotification.Should().NotBeNull();
@@ -68,7 +68,7 @@ namespace Sinch.Tests.Conversation.SinchEvents
             var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
             await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
-            var result = await _sinchEvents.ParseEventAsync(stream);
+            var result = await _conversationSinchEvents.ParseEventAsync(stream);
 
             result.Should().BeOfType<CapabilityEvent>();
             result.As<CapabilityEvent>().CapabilityNotification.Should().NotBeNull();

--- a/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
+using Sinch.Conversation;
 using Sinch.Conversation.SinchEvents;
 using Xunit;
 
@@ -15,13 +16,15 @@ namespace Sinch.Tests.Conversation.SinchEvents
         private const string NonceHeader = "x-sinch-webhook-signature-nonce";
         private const string AlgorithmHeader = "x-sinch-webhook-signature-algorithm";
         private const string SignatureHeader = "x-sinch-webhook-signature";
+        
+        private readonly ConversationSinchEvents _sinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
 
         [Fact]
         public void ValidateAuthenticationHeader_WithSingleValueHeaders_ReturnsTrue()
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");
 
-            var isValid = Conversation.SinchEvents.ValidateAuthenticationHeader(new Dictionary<string, string>()
+            var isValid = _sinchEvents.ValidateAuthenticationHeader(new Dictionary<string, string>()
             {
                 { NonceHeader, "01FJA8B4A7BM43YGWSG9GBV067" },
                 { TimestampHeader, "1634579353" },
@@ -37,7 +40,7 @@ namespace Sinch.Tests.Conversation.SinchEvents
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");
 
-            var isValid = Conversation.SinchEvents.ValidateAuthenticationHeader(new Dictionary<string, IEnumerable<string>>()
+            var isValid = _sinchEvents.ValidateAuthenticationHeader(new Dictionary<string, IEnumerable<string>>()
             {
                 { NonceHeader, ["01FJA8B4A7BM43YGWSG9GBV067"] },
                 { TimestampHeader, ["1634579353"] },
@@ -53,7 +56,7 @@ namespace Sinch.Tests.Conversation.SinchEvents
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
 
-            var result = Conversation.SinchEvents.ParseEvent(json);
+            var result = _sinchEvents.ParseEvent(json);
 
             result.Should().BeOfType<CapabilityEvent>();
             result.As<CapabilityEvent>().CapabilityNotification.Should().NotBeNull();
@@ -65,7 +68,7 @@ namespace Sinch.Tests.Conversation.SinchEvents
             var json = Helpers.LoadResources("Conversation/SinchEvents/CapabilityEvent.json");
             await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(json));
 
-            var result = await Conversation.SinchEvents.ParseEventAsync(stream);
+            var result = await _sinchEvents.ParseEventAsync(stream);
 
             result.Should().BeOfType<CapabilityEvent>();
             result.As<CapabilityEvent>().CapabilityNotification.Should().NotBeNull();

--- a/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
@@ -20,22 +20,6 @@ namespace Sinch.Tests.Conversation.SinchEvents
         private readonly ConversationSinchEvents _conversationSinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
 
         [Fact]
-        public void ValidateAuthenticationHeader_WithSingleValueHeaders_ReturnsTrue()
-        {
-            var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");
-
-            var isValid = _conversationSinchEvents.ValidateAuthenticationHeader(new Dictionary<string, string>()
-            {
-                { NonceHeader, "01FJA8B4A7BM43YGWSG9GBV067" },
-                { TimestampHeader, "1634579353" },
-                { AlgorithmHeader, "HmacSHA256" },
-                { SignatureHeader, "wKmZBGo4Cf+y9cZoPHhiVw6ziKeubLGqN4OdG8jlaPo=" },
-            }, json, SinchEventSecret);
-
-            isValid.Should().BeTrue();
-        }
-
-        [Fact]
         public void ValidateAuthenticationHeader_WithMultiValueHeaders_ReturnsTrue()
         {
             var json = Helpers.LoadResources("Conversation/SinchEvents/SinchEventsAuthValidation.json");

--- a/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Conversation/SinchEvents/SinchEventsTests.cs
@@ -16,7 +16,7 @@ namespace Sinch.Tests.Conversation.SinchEvents
         private const string NonceHeader = "x-sinch-webhook-signature-nonce";
         private const string AlgorithmHeader = "x-sinch-webhook-signature-algorithm";
         private const string SignatureHeader = "x-sinch-webhook-signature";
-        
+
         private readonly ConversationSinchEvents _conversationSinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
 
         [Fact]

--- a/tests/Sinch.Tests/Core/AuthenticationHeaderValidationTests.cs
+++ b/tests/Sinch.Tests/Core/AuthenticationHeaderValidationTests.cs
@@ -1,10 +1,13 @@
 #nullable enable
 using FluentAssertions;
-using Sinch.Verification;
-using Sinch.Voice;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Sinch.Auth;
+using Sinch.Verification.SinchEvents;
+using Sinch.Voice.SinchEvents;
 using Xunit;
 
 namespace Sinch.Tests.Core
@@ -14,25 +17,20 @@ namespace Sinch.Tests.Core
     /// </summary>
     public class AuthenticationHeaderValidationTests
     {
-        private readonly ISinchVoiceClient _voiceClient = new SinchClient(new SinchClientConfiguration()
-        {
-            VoiceConfiguration = new SinchVoiceConfiguration()
+        private static readonly ApplicationSignedAuth ApplicationSignedAuth =
+            new("669E367E-6BBA-48AB-AF15-266871C28135", "BeIukql3pTKJ8RGL5zo0DA==");
+        
+        private readonly VerificationSinchEvents _verificationSinchEvents = new(ApplicationSignedAuth);
+        
+        private readonly VoiceSinchEvents _voiceSinchEvents = new(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web)
             {
-                AppKey = "669E367E-6BBA-48AB-AF15-266871C28135",
-                AppSecret = "BeIukql3pTKJ8RGL5zo0DA=="
-            }
-        }).Voice;
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            },
+            ApplicationSignedAuth);
 
-        private readonly ISinchVerificationClient _verificationClient = new SinchClient(new SinchClientConfiguration()
-        {
-            VerificationConfiguration = new SinchVerificationConfiguration()
-            {
-                AppKey = "669E367E-6BBA-48AB-AF15-266871C28135",
-                AppSecret = "BeIukql3pTKJ8RGL5zo0DA=="
-            }
-        }).Verification;
-
-        private string _body =
+        private const string Body =
             "{\"event\":\"ace\",\"callid\":\"822aa4b7-05b4-4d83-87c7-1f835ee0b6f6_257\",\"timestamp\":\"2014-09-24T10:59:41Z\",\"version\":1}";
 
         private Dictionary<string, IEnumerable<string>> SetupTestHeaders(string timestamp, string? auth, string contentType)
@@ -55,10 +53,10 @@ namespace Sinch.Tests.Core
             string body,
             bool expected)
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(httpMethod, path,
+            _voiceSinchEvents.ValidateAuthenticationHeader(httpMethod, path,
                 headers, body).Should().Be(expected);
 
-            _verificationClient.ValidateAuthenticationHeader(httpMethod, path,
+            _verificationSinchEvents.ValidateAuthenticationHeader(httpMethod, path,
                 headers, body).Should().Be(expected);
         }
 
@@ -71,7 +69,7 @@ namespace Sinch.Tests.Core
                 "application 669E367E-6BBA-48AB-AF15-266871C28135:Tg6fMyo8mj9pYfWQ9ssbx3Tc1BNC87IEygAfLbJqZb4=",
                 "application/json");
 
-            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, _body,
+            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, Body,
                 expected: true);
         }
 
@@ -82,7 +80,7 @@ namespace Sinch.Tests.Core
                 "application 669E367E-6BBA-48AB-AF15-266871C28135:bdJO/XUVvIsb5SlZAKmvfw==",
                 "application/json");
 
-            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, _body,
+            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, Body,
                 expected: false);
         }
 
@@ -93,7 +91,7 @@ namespace Sinch.Tests.Core
                 null,
                 "application/json");
 
-            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, _body,
+            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, Body,
                 expected: false);
         }
 
@@ -104,7 +102,7 @@ namespace Sinch.Tests.Core
                 "application 669E367E-6BBA-48AB-AF15-266871C28135:Tg6fMyo8mj9pYfWQ9ssbx3Tc1BNC87IEygAfLbJqZb4=",
                 "application/json");
 
-            AssertHeaderValidation(headers, "/not/that/path", HttpMethod.Post, _body,
+            AssertHeaderValidation(headers, "/not/that/path", HttpMethod.Post, Body,
                 expected: false);
         }
 
@@ -115,7 +113,7 @@ namespace Sinch.Tests.Core
                 "application 669E367E-6BBA-48AB-AF15-266871C28135:Tg6fMyo8mj9pYfWQ9ssbx3Tc1BNC87IEygAfLbJqZb4=",
                 "application/json");
 
-            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Get, _body,
+            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Get, Body,
                 expected: false);
         }
 
@@ -126,7 +124,7 @@ namespace Sinch.Tests.Core
                 "application 669E367E-6BBA-48AB-AF15-266871C28135:Tg6fMyo8mj9pYfWQ9ssbx3Tc1BNC87IEygAfLbJqZb4=",
                 "application/json");
 
-            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, _body,
+            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, Body,
                 expected: false);
         }
 
@@ -137,7 +135,7 @@ namespace Sinch.Tests.Core
                 "application 669E367E-6BBA-48AB-AF15-266871C28135:Tg6fMyo8mj9pYfWQ9ssbx3Tc1BNC87IEygAfLbJqZb4=",
                 "text/html");
 
-            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, _body,
+            AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post, Body,
                 expected: false);
         }
 
@@ -162,7 +160,7 @@ namespace Sinch.Tests.Core
                 "application/json");
 
             AssertHeaderValidation(headers, "/sinch/callback/ace", HttpMethod.Post,
-                _body, expected: false);
+                Body, expected: false);
         }
     }
 }

--- a/tests/Sinch.Tests/Core/AuthenticationHeaderValidationTests.cs
+++ b/tests/Sinch.Tests/Core/AuthenticationHeaderValidationTests.cs
@@ -19,9 +19,9 @@ namespace Sinch.Tests.Core
     {
         private static readonly ApplicationSignedAuth ApplicationSignedAuth =
             new("669E367E-6BBA-48AB-AF15-266871C28135", "BeIukql3pTKJ8RGL5zo0DA==");
-        
+
         private readonly VerificationSinchEvents _verificationSinchEvents = new(ApplicationSignedAuth);
-        
+
         private readonly VoiceSinchEvents _voiceSinchEvents = new(
             new JsonSerializerOptions(JsonSerializerDefaults.Web)
             {

--- a/tests/Sinch.Tests/Core/AuthenticationHeaderValidationTests.cs
+++ b/tests/Sinch.Tests/Core/AuthenticationHeaderValidationTests.cs
@@ -55,7 +55,7 @@ namespace Sinch.Tests.Core
             string body,
             bool expected)
         {
-            _voiceClient.ValidateAuthenticationHeader(httpMethod, path,
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(httpMethod, path,
                 headers, body).Should().Be(expected);
 
             _verificationClient.ValidateAuthenticationHeader(httpMethod, path,

--- a/tests/Sinch.Tests/Sms/HmacAuthenticationValidationTests.cs
+++ b/tests/Sinch.Tests/Sms/HmacAuthenticationValidationTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using FluentAssertions;
+using Sinch.SMS.SinchEvents;
 using Xunit;
 
 namespace Sinch.Tests.Sms
@@ -32,7 +33,7 @@ namespace Sinch.Tests.Sms
             };
 
             // Act
-            var result = SMS.HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
+            var result = HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
 
             // Assert
             result.Should().BeTrue();
@@ -57,7 +58,7 @@ namespace Sinch.Tests.Sms
             };
 
             // Act
-            Action act = () => SMS.HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
+            Action act = () => HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
 
             // Assert
             act.Should().Throw<NotSupportedException>().WithMessage("*Unsupported HMAC algorithm*");
@@ -83,7 +84,7 @@ namespace Sinch.Tests.Sms
             headers.Remove(missingHeader);
 
             // Act
-            var result = SMS.HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
+            var result = HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
 
             // Assert
             result.Should().BeFalse();
@@ -116,7 +117,7 @@ namespace Sinch.Tests.Sms
             };
 
             // Act
-            var result = SMS.HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
+            var result = HmacAuthenticationValidation.ValidateAuthenticationHeader(secret, headers, jsonPayload);
 
             // Assert
             result.Should().BeFalse();

--- a/tests/Sinch.Tests/Sms/HmacAuthenticationValidationTests.cs
+++ b/tests/Sinch.Tests/Sms/HmacAuthenticationValidationTests.cs
@@ -24,12 +24,12 @@ namespace Sinch.Tests.Sms
             var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes(toBeSigned));
             var signature = Convert.ToBase64String(hash);
 
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                ["x-sinch-webhook-signature-timestamp"] = timestamp,
-                ["x-sinch-webhook-signature-nonce"] = nonce,
-                ["x-sinch-webhook-signature-algorithm"] = algorithm,
-                ["x-sinch-webhook-signature"] = signature
+                ["x-sinch-webhook-signature-timestamp"] = [timestamp],
+                ["x-sinch-webhook-signature-nonce"] = [nonce],
+                ["x-sinch-webhook-signature-algorithm"] = [algorithm],
+                ["x-sinch-webhook-signature"] = [signature]
             };
 
             // Act
@@ -49,12 +49,12 @@ namespace Sinch.Tests.Sms
             const string nonce = "nonce-value";
             const string algorithm = "HmacSHA512"; // unsupported
 
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                ["x-sinch-webhook-signature-timestamp"] = timestamp,
-                ["x-sinch-webhook-signature-nonce"] = nonce,
-                ["x-sinch-webhook-signature-algorithm"] = algorithm,
-                ["x-sinch-webhook-signature"] = "whatever"
+                ["x-sinch-webhook-signature-timestamp"] = [timestamp],
+                ["x-sinch-webhook-signature-nonce"] = [nonce],
+                ["x-sinch-webhook-signature-algorithm"] = [algorithm],
+                ["x-sinch-webhook-signature"] = ["whatever"]
             };
 
             // Act
@@ -72,12 +72,12 @@ namespace Sinch.Tests.Sms
             const string secret = "secret";
             const string jsonPayload = "{}";
 
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                ["x-sinch-webhook-signature-timestamp"] = "123",
-                ["x-sinch-webhook-signature-nonce"] = "n",
-                ["x-sinch-webhook-signature-algorithm"] = "HmacSHA256",
-                ["x-sinch-webhook-signature"] = "s"
+                ["x-sinch-webhook-signature-timestamp"] = ["123"],
+                ["x-sinch-webhook-signature-nonce"] = ["n"],
+                ["x-sinch-webhook-signature-algorithm"] = ["HmacSHA256"],
+                ["x-sinch-webhook-signature"] = ["s"]
             };
 
             // Remove the header under test
@@ -108,12 +108,12 @@ namespace Sinch.Tests.Sms
             const string nonce = "n";
             const string algorithm = "HmacSHA256";
 
-            var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            var headers = new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                ["x-sinch-webhook-signature-timestamp"] = timestamp,
-                ["x-sinch-webhook-signature-nonce"] = nonce,
-                ["x-sinch-webhook-signature-algorithm"] = algorithm,
-                ["x-sinch-webhook-signature"] = "sig"
+                ["x-sinch-webhook-signature-timestamp"] = [timestamp],
+                ["x-sinch-webhook-signature-nonce"] = [nonce],
+                ["x-sinch-webhook-signature-algorithm"] = [algorithm],
+                ["x-sinch-webhook-signature"] = ["sig"]
             };
 
             // Act

--- a/tests/Sinch.Tests/Sms/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Sms/SinchEventsTests.cs
@@ -12,14 +12,14 @@ namespace Sinch.Tests.Sms
 {
     public class SinchEventsTests : SmsTestBase
     {
-        private readonly SmsSinchEvents _sinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
+        private readonly SmsSinchEvents _smsSinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
 
         [Fact]
         public void DeserializeDeliveryReport()
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/DeliveryReportSms.json");
 
-            var parsed = _sinchEvents.ParseEvent(json).As<BatchDeliveryReportSms>();
+            var parsed = _smsSinchEvents.ParseEvent(json).As<BatchDeliveryReportSms>();
             AssertDeliveryReport(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BatchDeliveryReportSms>();
@@ -51,7 +51,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/RecipientDeliveryReportSms.json");
 
-            var parsed = _sinchEvents.ParseEvent(json).As<RecipientDeliveryReportSms>();
+            var parsed = _smsSinchEvents.ParseEvent(json).As<RecipientDeliveryReportSms>();
             AssertRecipient(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportSms>();
@@ -81,7 +81,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundBinary.json");
 
-            var parsed = _sinchEvents.ParseEvent(json).As<BinaryInbound>();
+            var parsed = _smsSinchEvents.ParseEvent(json).As<BinaryInbound>();
             AssertBinary(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BinaryInbound>();
@@ -109,7 +109,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundText.json");
 
-            var parsed = _sinchEvents.ParseEvent(json).As<SmsInbound>();
+            var parsed = _smsSinchEvents.ParseEvent(json).As<SmsInbound>();
             AssertText(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<SmsInbound>();
@@ -136,7 +136,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundMedia.json");
 
-            var parsed = _sinchEvents.ParseEvent(json).As<MediaInbound>();
+            var parsed = _smsSinchEvents.ParseEvent(json).As<MediaInbound>();
             AssertMedia(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<MediaInbound>();
@@ -177,7 +177,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/BatchDeliveryReportMms.json");
 
-            var parsed = _sinchEvents.ParseEvent(json).As<BatchDeliveryReportMms>();
+            var parsed = _smsSinchEvents.ParseEvent(json).As<BatchDeliveryReportMms>();
             AssertBatch(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BatchDeliveryReportMms>();
@@ -203,7 +203,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/RecipientDeliveryReportMms.json");
 
-            var parsed = _sinchEvents.ParseEvent(json).As<RecipientDeliveryReportMms>();
+            var parsed = _smsSinchEvents.ParseEvent(json).As<RecipientDeliveryReportMms>();
             AssertRecipient(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportMms>();
@@ -235,7 +235,7 @@ namespace Sinch.Tests.Sms
             var payload = "{\"unknownProperty\":\"anyValue\"}";
 
             // Act
-            Action act = () => _sinchEvents.ParseEvent(payload);
+            Action act = () => _smsSinchEvents.ParseEvent(payload);
 
             // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*Deserialization of SMS Sinch event failed*");
@@ -248,7 +248,7 @@ namespace Sinch.Tests.Sms
             var payload = "{\"type\":\"unknown\"}";
 
             // Act
-            Action act = () => _sinchEvents.ParseEvent(payload);
+            Action act = () => _smsSinchEvents.ParseEvent(payload);
 
             // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*Deserialization of SMS Sinch event failed*");

--- a/tests/Sinch.Tests/Sms/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Sms/SinchEventsTests.cs
@@ -15,10 +15,10 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/DeliveryReportSms.json");
 
-            var parsed = Sms.SmsSinchEvents.ParseEvent(json).As<BatchDeliveryReportSms>();
+            var parsed = Sms.SinchEvents.ParseEvent(json).As<BatchDeliveryReportSms>();
             AssertDeliveryReport(parsed);
 
-            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SmsSinchEvents.JsonSerializerOptions).As<BatchDeliveryReportSms>();
+            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BatchDeliveryReportSms>();
             AssertDeliveryReport(deserialized);
 
             void AssertDeliveryReport(BatchDeliveryReportSms report)
@@ -47,10 +47,10 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/RecipientDeliveryReportSms.json");
 
-            var parsed = Sms.SmsSinchEvents.ParseEvent(json).As<RecipientDeliveryReportSms>();
+            var parsed = Sms.SinchEvents.ParseEvent(json).As<RecipientDeliveryReportSms>();
             AssertRecipient(parsed);
 
-            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SmsSinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportSms>();
+            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportSms>();
             AssertRecipient(deserialized);
 
             void AssertRecipient(RecipientDeliveryReportSms report)
@@ -77,10 +77,10 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundBinary.json");
 
-            var parsed = Sms.SmsSinchEvents.ParseEvent(json).As<BinaryInbound>();
+            var parsed = Sms.SinchEvents.ParseEvent(json).As<BinaryInbound>();
             AssertBinary(parsed);
 
-            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SmsSinchEvents.JsonSerializerOptions).As<BinaryInbound>();
+            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BinaryInbound>();
             AssertBinary(deserialized);
 
             void AssertBinary(BinaryInbound report)
@@ -105,10 +105,10 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundText.json");
 
-            var parsed = Sms.SmsSinchEvents.ParseEvent(json).As<SmsInbound>();
+            var parsed = Sms.SinchEvents.ParseEvent(json).As<SmsInbound>();
             AssertText(parsed);
 
-            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SmsSinchEvents.JsonSerializerOptions).As<SmsInbound>();
+            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<SmsInbound>();
             AssertText(deserialized);
 
             void AssertText(SmsInbound report)
@@ -132,10 +132,10 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundMedia.json");
 
-            var parsed = Sms.SmsSinchEvents.ParseEvent(json).As<MediaInbound>();
+            var parsed = Sms.SinchEvents.ParseEvent(json).As<MediaInbound>();
             AssertMedia(parsed);
 
-            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SmsSinchEvents.JsonSerializerOptions).As<MediaInbound>();
+            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<MediaInbound>();
             AssertMedia(deserialized);
 
             void AssertMedia(MediaInbound evt)
@@ -173,10 +173,10 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/BatchDeliveryReportMms.json");
 
-            var parsed = Sms.SmsSinchEvents.ParseEvent(json).As<BatchDeliveryReportMms>();
+            var parsed = Sms.SinchEvents.ParseEvent(json).As<BatchDeliveryReportMms>();
             AssertBatch(parsed);
 
-            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SmsSinchEvents.JsonSerializerOptions).As<BatchDeliveryReportMms>();
+            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BatchDeliveryReportMms>();
             AssertBatch(deserialized);
 
             void AssertBatch(BatchDeliveryReportMms report)
@@ -199,10 +199,10 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/RecipientDeliveryReportMms.json");
 
-            var parsed = Sms.SmsSinchEvents.ParseEvent(json).As<RecipientDeliveryReportMms>();
+            var parsed = Sms.SinchEvents.ParseEvent(json).As<RecipientDeliveryReportMms>();
             AssertRecipient(parsed);
 
-            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SmsSinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportMms>();
+            var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportMms>();
             AssertRecipient(deserialized);
 
             void AssertRecipient(RecipientDeliveryReportMms report)
@@ -231,7 +231,7 @@ namespace Sinch.Tests.Sms
             var payload = "{\"unknownProperty\":\"anyValue\"}";
 
             // Act
-            Action act = () => Sms.SmsSinchEvents.ParseEvent(payload);
+            Action act = () => Sms.SinchEvents.ParseEvent(payload);
 
             // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*Deserialization of SMS Sinch event failed*");
@@ -244,7 +244,7 @@ namespace Sinch.Tests.Sms
             var payload = "{\"type\":\"unknown\"}";
 
             // Act
-            Action act = () => Sms.SmsSinchEvents.ParseEvent(payload);
+            Action act = () => Sms.SinchEvents.ParseEvent(payload);
 
             // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*Deserialization of SMS Sinch event failed*");

--- a/tests/Sinch.Tests/Sms/SinchEventsTests.cs
+++ b/tests/Sinch.Tests/Sms/SinchEventsTests.cs
@@ -1,21 +1,25 @@
 using System;
 using System.Text.Json;
 using FluentAssertions;
+using Sinch.Conversation;
 using Sinch.SMS;
 using Sinch.SMS.DeliveryReports;
 using Sinch.SMS.Inbounds;
+using Sinch.SMS.SinchEvents;
 using Xunit;
 
 namespace Sinch.Tests.Sms
 {
     public class SinchEventsTests : SmsTestBase
     {
+        private readonly SmsSinchEvents _sinchEvents = new(SinchConversationClient.JsonSerializerOptionsInner);
+
         [Fact]
         public void DeserializeDeliveryReport()
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/DeliveryReportSms.json");
 
-            var parsed = Sms.SinchEvents.ParseEvent(json).As<BatchDeliveryReportSms>();
+            var parsed = _sinchEvents.ParseEvent(json).As<BatchDeliveryReportSms>();
             AssertDeliveryReport(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BatchDeliveryReportSms>();
@@ -47,7 +51,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/RecipientDeliveryReportSms.json");
 
-            var parsed = Sms.SinchEvents.ParseEvent(json).As<RecipientDeliveryReportSms>();
+            var parsed = _sinchEvents.ParseEvent(json).As<RecipientDeliveryReportSms>();
             AssertRecipient(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportSms>();
@@ -77,7 +81,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundBinary.json");
 
-            var parsed = Sms.SinchEvents.ParseEvent(json).As<BinaryInbound>();
+            var parsed = _sinchEvents.ParseEvent(json).As<BinaryInbound>();
             AssertBinary(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BinaryInbound>();
@@ -105,7 +109,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundText.json");
 
-            var parsed = Sms.SinchEvents.ParseEvent(json).As<SmsInbound>();
+            var parsed = _sinchEvents.ParseEvent(json).As<SmsInbound>();
             AssertText(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<SmsInbound>();
@@ -132,7 +136,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/InboundMedia.json");
 
-            var parsed = Sms.SinchEvents.ParseEvent(json).As<MediaInbound>();
+            var parsed = _sinchEvents.ParseEvent(json).As<MediaInbound>();
             AssertMedia(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<MediaInbound>();
@@ -173,7 +177,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/BatchDeliveryReportMms.json");
 
-            var parsed = Sms.SinchEvents.ParseEvent(json).As<BatchDeliveryReportMms>();
+            var parsed = _sinchEvents.ParseEvent(json).As<BatchDeliveryReportMms>();
             AssertBatch(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<BatchDeliveryReportMms>();
@@ -199,7 +203,7 @@ namespace Sinch.Tests.Sms
         {
             var json = Helpers.LoadResources("Sms/SinchEvents/RecipientDeliveryReportMms.json");
 
-            var parsed = Sms.SinchEvents.ParseEvent(json).As<RecipientDeliveryReportMms>();
+            var parsed = _sinchEvents.ParseEvent(json).As<RecipientDeliveryReportMms>();
             AssertRecipient(parsed);
 
             var deserialized = JsonSerializer.Deserialize<ISmsSinchEvent>(json, Sms.SinchEvents.JsonSerializerOptions).As<RecipientDeliveryReportMms>();
@@ -231,7 +235,7 @@ namespace Sinch.Tests.Sms
             var payload = "{\"unknownProperty\":\"anyValue\"}";
 
             // Act
-            Action act = () => Sms.SinchEvents.ParseEvent(payload);
+            Action act = () => _sinchEvents.ParseEvent(payload);
 
             // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*Deserialization of SMS Sinch event failed*");
@@ -244,7 +248,7 @@ namespace Sinch.Tests.Sms
             var payload = "{\"type\":\"unknown\"}";
 
             // Act
-            Action act = () => Sms.SinchEvents.ParseEvent(payload);
+            Action act = () => _sinchEvents.ParseEvent(payload);
 
             // Assert
             act.Should().Throw<InvalidOperationException>().WithMessage("*Deserialization of SMS Sinch event failed*");

--- a/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
+++ b/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
@@ -15,8 +15,8 @@ namespace Sinch.Tests.Voice
     public class DeserializeVoiceSinchEventsTests
     {
         private static readonly JsonSerializerOptions SerializationOptions = new(JsonSerializerDefaults.Web);
-        private static readonly ApplicationSignedAuth Auth = new ("appkey", "appsecret");
-        private readonly VoiceSinchEvents _voiceSinchEvents = new (SerializationOptions, Auth);
+        private static readonly ApplicationSignedAuth Auth = new("appkey", "appsecret");
+        private readonly VoiceSinchEvents _voiceSinchEvents = new(SerializationOptions, Auth);
 
         [Fact]
         public void DeserializeAce()

--- a/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
+++ b/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
@@ -27,13 +27,13 @@ namespace Sinch.Tests.Voice
         {
             var json = Helpers.LoadResources("Voice/AnsweredCallEvent.json");
 
-            var @event = JsonSerializer.Deserialize<VoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.ParseEvent(json);
+            var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
+            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
 
-            void AssertEvent(VoiceSinchEvent parsed)
+            void AssertEvent(IVoiceSinchEvent parsed)
             {
                 parsed.As<AnsweredCallEvent>().Should().BeEquivalentTo(new AnsweredCallEvent
                 {
@@ -58,13 +58,13 @@ namespace Sinch.Tests.Voice
         {
             var json = Helpers.LoadResources("Voice/NotificationEvent.json");
 
-            var @event = JsonSerializer.Deserialize<VoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.ParseEvent(json);
+            var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
+            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
 
-            void AssertEvent(VoiceSinchEvent parsed)
+            void AssertEvent(IVoiceSinchEvent parsed)
             {
                 parsed.As<NotificationEvent>().Should().BeEquivalentTo(new NotificationEvent
                 {
@@ -89,13 +89,13 @@ namespace Sinch.Tests.Voice
         public void DeserializePromptInputEvent()
         {
             var json = Helpers.LoadResources("Voice/PromptInputEvent.json");
-            var @event = JsonSerializer.Deserialize<VoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.ParseEvent(json);
+            var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
+            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
 
-            void AssertEvent(VoiceSinchEvent parsed)
+            void AssertEvent(IVoiceSinchEvent parsed)
             {
                 parsed.As<PromptInputEvent>().Should().BeEquivalentTo(new PromptInputEvent
                 {
@@ -122,13 +122,13 @@ namespace Sinch.Tests.Voice
         {
             var json = Helpers.LoadResources("Voice/DisconnectedCallEvent.json");
 
-            var @event = JsonSerializer.Deserialize<VoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.ParseEvent(json);
+            var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
+            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
 
-            void AssertEvent(VoiceSinchEvent parsed)
+            void AssertEvent(IVoiceSinchEvent parsed)
             {
                 parsed.As<DisconnectedCallEvent>().Should().BeEquivalentTo(new DisconnectedCallEvent
                 {
@@ -167,13 +167,13 @@ namespace Sinch.Tests.Voice
         {
             var json = Helpers.LoadResources("Voice/IncomingCallEvent.json");
 
-            var @event = JsonSerializer.Deserialize<VoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.ParseEvent(json);
+            var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
+            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
 
-            void AssertEvent(VoiceSinchEvent parsed)
+            void AssertEvent(IVoiceSinchEvent parsed)
             {
                 parsed.As<IncomingCallEvent>().Should().BeEquivalentTo(new IncomingCallEvent
                 {

--- a/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
+++ b/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
@@ -1,6 +1,10 @@
 using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using FluentAssertions;
+using Sinch.Auth;
+using Sinch.Logger;
+using Sinch.Numbers.VoiceConfigurations;
 using Sinch.Voice;
 using Sinch.Voice.Callouts.Callout;
 using Sinch.Voice.Calls;
@@ -13,14 +17,9 @@ namespace Sinch.Tests.Voice
 {
     public class DeserializeVoiceSinchEventsTests
     {
-        private readonly ISinchVoiceClient _voiceClient = new SinchClient(new SinchClientConfiguration()
-        {
-            VoiceConfiguration = new SinchVoiceConfiguration()
-            {
-                AppKey = "appkey",
-                AppSecret = "appsecret",
-            }
-        }).Voice;
+        private static readonly JsonSerializerOptions SerializationOptions = new(JsonSerializerDefaults.Web);
+        private static readonly ApplicationSignedAuth Auth = new ("appkey", "appsecret");
+        private readonly VoiceSinchEvents _sinchEvents = new (SerializationOptions, Auth);
 
         [Fact]
         public void DeserializeAce()
@@ -28,7 +27,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/AnsweredCallEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
+            var eventWithClient = _sinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -59,7 +58,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/NotificationEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
+            var eventWithClient = _sinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -90,7 +89,7 @@ namespace Sinch.Tests.Voice
         {
             var json = Helpers.LoadResources("Voice/PromptInputEvent.json");
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
+            var eventWithClient = _sinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -123,7 +122,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/DisconnectedCallEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
+            var eventWithClient = _sinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -168,7 +167,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/IncomingCallEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _voiceClient.SinchEvents.ParseEvent(json);
+            var eventWithClient = _sinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);

--- a/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
+++ b/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
@@ -19,7 +19,7 @@ namespace Sinch.Tests.Voice
     {
         private static readonly JsonSerializerOptions SerializationOptions = new(JsonSerializerDefaults.Web);
         private static readonly ApplicationSignedAuth Auth = new ("appkey", "appsecret");
-        private readonly VoiceSinchEvents _sinchEvents = new (SerializationOptions, Auth);
+        private readonly VoiceSinchEvents _voiceSinchEvents = new (SerializationOptions, Auth);
 
         [Fact]
         public void DeserializeAce()
@@ -27,7 +27,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/AnsweredCallEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _sinchEvents.ParseEvent(json);
+            var eventWithClient = _voiceSinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -58,7 +58,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/NotificationEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _sinchEvents.ParseEvent(json);
+            var eventWithClient = _voiceSinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -89,7 +89,7 @@ namespace Sinch.Tests.Voice
         {
             var json = Helpers.LoadResources("Voice/PromptInputEvent.json");
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _sinchEvents.ParseEvent(json);
+            var eventWithClient = _voiceSinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -122,7 +122,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/DisconnectedCallEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _sinchEvents.ParseEvent(json);
+            var eventWithClient = _voiceSinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);
@@ -167,7 +167,7 @@ namespace Sinch.Tests.Voice
             var json = Helpers.LoadResources("Voice/IncomingCallEvent.json");
 
             var @event = JsonSerializer.Deserialize<IVoiceSinchEvent>(json);
-            var eventWithClient = _sinchEvents.ParseEvent(json);
+            var eventWithClient = _voiceSinchEvents.ParseEvent(json);
 
             AssertEvent(@event);
             AssertEvent(eventWithClient);

--- a/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
+++ b/tests/Sinch.Tests/Voice/DeserializeVoiceSinchEventsTests.cs
@@ -1,10 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using FluentAssertions;
 using Sinch.Auth;
-using Sinch.Logger;
-using Sinch.Numbers.VoiceConfigurations;
 using Sinch.Voice;
 using Sinch.Voice.Callouts.Callout;
 using Sinch.Voice.Calls;

--- a/tests/Sinch.Tests/Voice/VoiceSinchEventsTests.cs
+++ b/tests/Sinch.Tests/Voice/VoiceSinchEventsTests.cs
@@ -1,29 +1,20 @@
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Text.Json;
 using FluentAssertions;
-using Sinch.Voice;
+using Sinch.Auth;
+using Sinch.Voice.SinchEvents;
 using Xunit;
 
 namespace Sinch.Tests.Voice
 {
     public class VoiceSinchEventsTests
     {
-        private readonly ISinchVoiceClient _voiceClient = new SinchClient(new SinchClientConfiguration()
-        {
-            SinchUnifiedCredentials = new SinchUnifiedCredentials()
-            {
-                ProjectId = "PROJECT_ID",
-                KeyId = "KEY_ID",
-                KeySecret = "KEY_SECRET",
-            },
-            VoiceConfiguration = new SinchVoiceConfiguration()
-            {
-                AppKey = "669E367E-6BBA-48AB-AF15-266871C28135",
-                AppSecret = "BeIukql3pTKJ8RGL5zo0DA=="
-            }
-        }).Voice;
+        private readonly VoiceSinchEvents _voiceSinchEvents = new(
+            new JsonSerializerOptions(JsonSerializerDefaults.Web),
+            new ApplicationSignedAuth("669E367E-6BBA-48AB-AF15-266871C28135", "BeIukql3pTKJ8RGL5zo0DA=="));
 
-        private string _body =
+        private const string Body =
             "{\"event\":\"ace\",\"callid\":\"822aa4b7-05b4-4d83-87c7-1f835ee0b6f6_257\",\"timestamp\":\"2014-09-24T10:59:41Z\",\"version\":1}";
 
         [Fact]
@@ -32,7 +23,7 @@ namespace Sinch.Tests.Voice
             // https://developers.sinch.com/docs/voice/api-reference/authentication/callback-signed-request/
             // full path: "https://callbacks.yourdomain.com/sinch/callback/ace"
 
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -45,13 +36,13 @@ namespace Sinch.Tests.Voice
                         }
                     }
                 }
-                , _body).Should().BeTrue();
+                , Body).Should().BeTrue();
         }
 
         [Fact]
         public void FailIfInvalidAuthHeaderValue()
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -64,25 +55,25 @@ namespace Sinch.Tests.Voice
                         }
                     }
                 }
-                , _body).Should().BeFalse();
+                , Body).Should().BeFalse();
         }
 
         [Fact]
         public void FailIfAuthHeaderMissing()
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
                     { "content-type", new[] { "application/json" } },
                 }
-                , _body).Should().BeFalse();
+                , Body).Should().BeFalse();
         }
 
         [Fact]
         public void FailIfInvalidPath()
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/not/that/path",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/not/that/path",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -95,13 +86,13 @@ namespace Sinch.Tests.Voice
                         }
                     }
                 }
-                , _body).Should().BeFalse();
+                , Body).Should().BeFalse();
         }
 
         [Fact]
         public void FailNotThatHttpMethod()
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Get, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Get, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -114,13 +105,13 @@ namespace Sinch.Tests.Voice
                         }
                     }
                 }
-                , _body).Should().BeFalse();
+                , Body).Should().BeFalse();
         }
 
         [Fact]
         public void FailNotThatTimestamp()
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2019-11-03T10:59:41Z" } },
@@ -133,13 +124,13 @@ namespace Sinch.Tests.Voice
                         }
                     }
                 }
-                , _body).Should().BeFalse();
+                , Body).Should().BeFalse();
         }
 
         [Fact]
         public void FailNotThatContentType()
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -152,14 +143,14 @@ namespace Sinch.Tests.Voice
                         }
                     }
                 }
-                , _body).Should().BeFalse();
+                , Body).Should().BeFalse();
         }
 
         [Fact]
         public void FailNotThatBody()
         {
             var differentBody = "{\"hello\":\"world\"}";
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -178,7 +169,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailNotApplicationHeader()
         {
-            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceSinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -191,7 +182,7 @@ namespace Sinch.Tests.Voice
                         }
                     }
                 }
-                , _body).Should().BeFalse();
+                , Body).Should().BeFalse();
         }
     }
 }

--- a/tests/Sinch.Tests/Voice/VoiceSinchEventsTests.cs
+++ b/tests/Sinch.Tests/Voice/VoiceSinchEventsTests.cs
@@ -32,7 +32,7 @@ namespace Sinch.Tests.Voice
             // https://developers.sinch.com/docs/voice/api-reference/authentication/callback-signed-request/
             // full path: "https://callbacks.yourdomain.com/sinch/callback/ace"
 
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -51,7 +51,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailIfInvalidAuthHeaderValue()
         {
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -70,7 +70,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailIfAuthHeaderMissing()
         {
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -82,7 +82,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailIfInvalidPath()
         {
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/not/that/path",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/not/that/path",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -101,7 +101,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailNotThatHttpMethod()
         {
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Get, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Get, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -120,7 +120,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailNotThatTimestamp()
         {
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2019-11-03T10:59:41Z" } },
@@ -139,7 +139,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailNotThatContentType()
         {
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -159,7 +159,7 @@ namespace Sinch.Tests.Voice
         public void FailNotThatBody()
         {
             var differentBody = "{\"hello\":\"world\"}";
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },
@@ -178,7 +178,7 @@ namespace Sinch.Tests.Voice
         [Fact]
         public void FailNotApplicationHeader()
         {
-            _voiceClient.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
+            _voiceClient.SinchEvents.ValidateAuthenticationHeader(HttpMethod.Post, "/sinch/callback/ace",
                 new Dictionary<string, IEnumerable<string>>()
                 {
                     { "x-timestamp", new[] { "2014-09-24T10:59:41Z" } },


### PR DESCRIPTION
## Summary

**1. Return type**
Every **ParseEvent** returns an interface following the` I{Domain}SinchEvent` pattern:

`ISmsSinchEvent` returned by `sinch.Sms.SinchEvents.ParseEvent()`
`IFaxSinchEvent` returned by `sinch.Fax.SinchEvents.ParseEvent()`
`IConversationSinchEvent` returned by `sinch.Conversation.SinchEvents.ParseEvent()`
`INumberSinchEvent` returned by `sinch.Numbers.SinchEvents.ParseEvent()`
`IVoiceSinchEvent` returned by `sinch.Voice.SinchEvents.ParseEvent()`

**2. Location**
All domains expose `ParseEvent()` and `ValidateAuthenticationHeader()` under `{Domain}SinchEvents` sub-domain.

**3. SinchEvents used in tests**
`{Domain}SinchEvents` instances are now used in tests to avoid creating heavy domain clients unnecessarily.

**4. SinchEvents implementation consistency**

All six `*SinchEvents` interfaces now share a consistent contract:` ParseEvent(string)`, `ParseEventAsync(Stream)`, `ValidateAuthenticationHeader(IDictionary<string, IEnumerable<string>>, ...)`, and a public `JsonSerializerOptions`. The only divergence is Verification, which has no `ParseEvent` by design.