### PR TITLE
Add explicit solution file builds to catch stale project paths

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,6 +95,12 @@ jobs:
       - name: Build Examples
         run: dotnet build examples/dirs.proj
 
+      - name: Build Snippets Solution
+        run: dotnet build examples/snippets/Snippets.sln
+
+      - name: Build Webhook Template Solution
+        run: dotnet build examples/templates/webhooks/Webhook.Template.sln
+
       - name: Test
         run: dotnet test tests/Sinch.Tests --framework ${{ matrix.tfm }} --no-restore --verbosity normal
 


### PR DESCRIPTION
## Summary

The `build.yaml` workflow uses dotnet build `examples/dirs.proj` (a traversal project) to build all example `.csproj` files. However, this only validates that individual projects compile, but it does not validate that the `.sln` files (`Snippets.sln`, `Webhook.Template.sln`) correctly reference those projects.

When folders are renamed (e.g., callbacks/ → event-destinations/), the `.csproj` files move but the `.sln` retains stale paths. The traversal project still finds and builds the` .csproj` at its new location, so CI passes, but the solution file is broken for anyone opening it in an IDE.

## Root Cause
`dirs.proj` discovers `.csproj` files by glob (`**\*.csproj`), completely bypassing solution-level path references.

## Fix
Add two new CI steps to cover solution file builds after the existing Build Examples step.

